### PR TITLE
feat(env): TaxiEnvWrapper with seeding, decoding and reward-shaping hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 - Utilitaires de reproductibilité (`src/utils/seeding.py`) : flux RNG indépendants,
   listes de seeds d'évaluation et de sondes disjointes
 - Configuration par défaut commentée (`configs/default.yaml`)
+- `TaxiEnvWrapper` : encapsulation Gymnasium Taxi-v3 (render ansi, `n_states`/`n_actions`,
+  `decode_state()`, hook de reward shaping avec `info["raw_reward"]`, seeding premier-reset,
+  graine explicite par épisode pour l'évaluation) + factory `create_env()`
 
 ### Changed
 

--- a/src/environments/__init__.py
+++ b/src/environments/__init__.py
@@ -1,1 +1,32 @@
 """Environment wrappers: Taxi-v3, multi-passenger extension, TrackMania."""
+
+from __future__ import annotations
+
+from src.config import Config
+from src.environments.taxi_wrapper import TAXI_LOCATIONS, RewardFn, TaxiEnvWrapper
+
+__all__ = ["TAXI_LOCATIONS", "RewardFn", "TaxiEnvWrapper", "create_env"]
+
+
+def create_env(config: Config, reward_fn: RewardFn | None = None) -> TaxiEnvWrapper:
+    """Build the environment described by the configuration.
+
+    Args:
+        config: Project configuration (``env``, ``seed``,
+            ``max_steps_per_episode``).
+        reward_fn: Optional reward-shaping function passed through to the
+            wrapper (wired by the benchmarking module).
+
+    Returns:
+        A ready-to-use environment wrapper.
+
+    Raises:
+        NotImplementedError: If ``config.env`` is ``"multi"`` (upcoming).
+    """
+    if config.env == "taxi":
+        return TaxiEnvWrapper(
+            reward_fn=reward_fn,
+            seed=config.seed,
+            max_steps=config.max_steps_per_episode,
+        )
+    raise NotImplementedError("coming in feature/multi-passenger")

--- a/src/environments/taxi_wrapper.py
+++ b/src/environments/taxi_wrapper.py
@@ -1,0 +1,157 @@
+"""Thin Gymnasium Taxi-v3 wrapper with seeding, decoding and reward-shaping hooks.
+
+The wrapper normalises the Gymnasium API for the rest of the project:
+
+- observations are plain built-in ``int`` and rewards plain ``float``;
+- the constructor seed is applied on the *first* reset only, following
+  Gymnasium 1.x episodic seeding semantics (subsequent bare resets continue
+  the RNG stream), while an explicit ``reset(seed=...)`` always re-seeds
+  (used by the evaluator to replay fixed test episodes);
+- an optional ``reward_fn`` shapes rewards while the native environment
+  reward is always preserved in ``info["raw_reward"]`` for uniform logging.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, SupportsInt, cast
+
+import gymnasium as gym
+from gymnasium.spaces import Discrete
+
+# Signature: (state, action, raw_reward, next_state) -> shaped_reward.
+RewardFn = Callable[[int, int, float, int], float]
+
+# Grid coordinates of the four Taxi-v3 landmarks (R, G, Y, B), mirroring
+# ``TaxiEnv.locs``. Used by distance-based reward shaping.
+TAXI_LOCATIONS: dict[int, tuple[int, int]] = {0: (0, 0), 1: (0, 4), 2: (4, 0), 3: (4, 3)}
+
+
+class TaxiEnvWrapper:
+    """Project-facing wrapper around the Gymnasium ``Taxi-v3`` environment.
+
+    Attributes:
+        env: The underlying Gymnasium environment (TimeLimit-wrapped).
+        reward_fn: Optional reward-shaping function applied on each step.
+    """
+
+    def __init__(
+        self,
+        reward_fn: RewardFn | None = None,
+        seed: int | None = None,
+        env_id: str = "Taxi-v3",
+        render_mode: str = "ansi",
+        max_steps: int | None = None,
+    ) -> None:
+        """Create the wrapped environment.
+
+        Args:
+            reward_fn: Optional shaping function ``(state, action, raw_reward,
+                next_state) -> shaped_reward``. When None, rewards pass through.
+            seed: Seed applied on the first :meth:`reset` only.
+            env_id: Gymnasium environment id.
+            render_mode: Gymnasium render mode (``"ansi"`` yields strings).
+            max_steps: Episode step limit. When set, it overrides the spec
+                default (200 for Taxi-v3) via ``gym.make(max_episode_steps=...)``,
+                avoiding a second nested TimeLimit wrapper.
+        """
+        make_kwargs: dict[str, Any] = {"render_mode": render_mode}
+        if max_steps is not None:
+            make_kwargs["max_episode_steps"] = max_steps
+        self.env: gym.Env[Any, Any] = gym.make(env_id, **make_kwargs)
+        self.reward_fn = reward_fn
+        self._seed = seed
+        self._seeded = False
+        self._state = 0
+
+    # ------------------------------------------------------------------ properties
+
+    @property
+    def n_states(self) -> int:
+        """Number of discrete states (500 for Taxi-v3)."""
+        space = self.env.observation_space
+        assert isinstance(space, Discrete)
+        # cast: numpy stubs make mypy infer ``Discrete.n`` as ``Any | np.void``.
+        return int(cast(SupportsInt, space.n))
+
+    @property
+    def n_actions(self) -> int:
+        """Number of discrete actions (6 for Taxi-v3)."""
+        space = self.env.action_space
+        assert isinstance(space, Discrete)
+        return int(cast(SupportsInt, space.n))
+
+    # ------------------------------------------------------------------ core API
+
+    def reset(self, seed: int | None = None) -> tuple[int, dict[str, Any]]:
+        """Reset the environment and return the initial state.
+
+        Args:
+            seed: Explicit episode seed. When given it is passed through
+                (fixed evaluation episodes). Otherwise the constructor seed is
+                used on the first reset only; later resets are bare so the
+                RNG stream continues (Gymnasium 1.x seeding semantics).
+
+        Returns:
+            Tuple ``(state, info)`` with ``state`` as a built-in int.
+        """
+        if seed is not None:
+            obs, info = self.env.reset(seed=seed)
+        elif not self._seeded:
+            obs, info = self.env.reset(seed=self._seed)
+        else:
+            obs, info = self.env.reset()
+        self._seeded = True
+        self._state = int(obs)
+        return self._state, info
+
+    def step(self, action: int) -> tuple[int, float, bool, bool, dict[str, Any]]:
+        """Take one environment step, applying reward shaping when configured.
+
+        Args:
+            action: Discrete action index.
+
+        Returns:
+            Tuple ``(next_state, reward, terminated, truncated, info)``.
+            ``reward`` is the shaped reward when ``reward_fn`` is set; the
+            native environment reward is always stored in
+            ``info["raw_reward"]``.
+        """
+        state_before = self._state
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        next_state = int(obs)
+        raw_reward = float(reward)
+        info["raw_reward"] = raw_reward
+        shaped = (
+            raw_reward
+            if self.reward_fn is None
+            else self.reward_fn(state_before, action, raw_reward, next_state)
+        )
+        self._state = next_state
+        return next_state, float(shaped), bool(terminated), bool(truncated), info
+
+    def render(self) -> str:
+        """Return the current ANSI rendering of the environment."""
+        frame: Any = self.env.render()
+        return frame if isinstance(frame, str) else ""
+
+    def close(self) -> None:
+        """Release the underlying environment resources."""
+        self.env.close()
+
+    # ------------------------------------------------------------------ helpers
+
+    def decode_state(self, state: int) -> tuple[int, int, int, int]:
+        """Decode an encoded Taxi-v3 state into its components.
+
+        Args:
+            state: Encoded state in ``[0, n_states)``.
+
+        Returns:
+            Tuple ``(taxi_row, taxi_col, passenger_loc, destination)`` where
+            ``passenger_loc`` is 0-3 for the landmarks or 4 when in the taxi,
+            and ``destination`` is a landmark index 0-3.
+        """
+        unwrapped = cast(Any, self.env.unwrapped)
+        taxi_row, taxi_col, passenger_loc, destination = (int(v) for v in unwrapped.decode(state))
+        return taxi_row, taxi_col, passenger_loc, destination

--- a/tests/environments/test_taxi_wrapper.py
+++ b/tests/environments/test_taxi_wrapper.py
@@ -1,0 +1,153 @@
+"""Tests for the Taxi-v3 wrapper: types, seeding, shaping, decoding, TimeLimit."""
+
+from typing import Any, cast
+
+import pytest
+
+from src.config import Config
+from src.environments import create_env
+from src.environments.taxi_wrapper import TAXI_LOCATIONS, TaxiEnvWrapper
+
+
+@pytest.fixture()
+def env() -> TaxiEnvWrapper:
+    return TaxiEnvWrapper(seed=42)
+
+
+class TestSpaces:
+    def test_n_states(self, env: TaxiEnvWrapper) -> None:
+        assert env.n_states == 500
+        assert isinstance(env.n_states, int)
+
+    def test_n_actions(self, env: TaxiEnvWrapper) -> None:
+        assert env.n_actions == 6
+        assert isinstance(env.n_actions, int)
+
+
+class TestResetAndStep:
+    def test_reset_returns_int_and_info(self, env: TaxiEnvWrapper) -> None:
+        state, info = env.reset()
+        assert type(state) is int
+        assert 0 <= state < 500
+        assert isinstance(info, dict)
+
+    def test_step_types(self, env: TaxiEnvWrapper) -> None:
+        env.reset()
+        state, reward, terminated, truncated, info = env.step(0)
+        assert type(state) is int
+        assert type(reward) is float
+        assert type(terminated) is bool
+        assert type(truncated) is bool
+        assert isinstance(info, dict)
+
+    def test_raw_reward_always_present(self, env: TaxiEnvWrapper) -> None:
+        env.reset()
+        _, reward, _, _, info = env.step(1)
+        assert "raw_reward" in info
+        assert info["raw_reward"] == reward
+
+
+class TestRewardShaping:
+    def test_shaped_reward_and_native_in_info(self) -> None:
+        env = TaxiEnvWrapper(reward_fn=lambda s, a, r, s2: r + 1.0, seed=42)
+        env.reset()
+        _, reward, _, _, info = env.step(0)
+        assert reward == info["raw_reward"] + 1.0
+
+    def test_shaping_fn_receives_transition(self) -> None:
+        seen: list[tuple[int, int, float, int]] = []
+
+        def spy(s: int, a: int, r: float, s2: int) -> float:
+            seen.append((s, a, r, s2))
+            return r
+
+        env = TaxiEnvWrapper(reward_fn=spy, seed=42)
+        start, _ = env.reset()
+        next_state, _, _, _, info = env.step(3)
+        assert seen == [(start, 3, info["raw_reward"], next_state)]
+
+
+class TestSeeding:
+    def test_same_constructor_seed_same_first_reset(self) -> None:
+        s1, _ = TaxiEnvWrapper(seed=7).reset()
+        s2, _ = TaxiEnvWrapper(seed=7).reset()
+        assert s1 == s2
+
+    def test_explicit_seed_reproducible_mid_sequence(self, env: TaxiEnvWrapper) -> None:
+        s1, _ = env.reset(seed=123)
+        env.step(0)
+        env.reset()  # advance the RNG stream mid-sequence
+        s2, _ = env.reset(seed=123)
+        assert s1 == s2
+
+    def test_bare_resets_do_not_reseed(self, env: TaxiEnvWrapper) -> None:
+        states = [env.reset()[0] for _ in range(5)]
+        assert len(set(states)) > 1
+
+
+class TestDecodeState:
+    def test_decode_ranges(self, env: TaxiEnvWrapper) -> None:
+        env.reset()
+        state, *_ = env.step(0)
+        decoded = env.decode_state(state)
+        assert len(decoded) == 4
+        row, col, passenger, destination = decoded
+        assert all(type(v) is int for v in decoded)
+        assert 0 <= row <= 4
+        assert 0 <= col <= 4
+        assert 0 <= passenger <= 4
+        assert 0 <= destination <= 3
+
+    def test_encode_decode_round_trip(self, env: TaxiEnvWrapper) -> None:
+        encoded = int(cast(Any, env.env.unwrapped).encode(3, 1, 2, 0))
+        row, col, passenger, destination = env.decode_state(encoded)
+        assert (row, col, passenger, destination) == (3, 1, 2, 0)
+        # Landmark indices map to the module-level grid coordinates.
+        assert TAXI_LOCATIONS[passenger] == (4, 0)
+        assert TAXI_LOCATIONS[destination] == (0, 0)
+
+    def test_taxi_locations_match_env(self, env: TaxiEnvWrapper) -> None:
+        locs = cast(Any, env.env.unwrapped).locs
+        assert {i: tuple(loc) for i, loc in enumerate(locs)} == TAXI_LOCATIONS
+
+
+class TestRender:
+    def test_render_returns_grid_string(self, env: TaxiEnvWrapper) -> None:
+        env.reset()
+        frame = env.render()
+        assert isinstance(frame, str)
+        assert frame
+        assert "+---------+" in frame
+
+
+class TestTimeLimit:
+    def test_truncated_after_max_steps(self) -> None:
+        env = TaxiEnvWrapper(seed=42, max_steps=10)
+        env.reset()
+        truncated = False
+        for _ in range(10):
+            _, _, terminated, truncated, _ = env.step(0)
+            assert not terminated  # action 0 (south) never ends the episode
+        assert truncated
+
+
+class TestFactory:
+    def test_create_env_taxi(self) -> None:
+        env = create_env(Config(seed=7, max_steps_per_episode=10))
+        assert isinstance(env, TaxiEnvWrapper)
+        env.reset()
+        truncated = False
+        for _ in range(10):
+            *_, truncated, _ = env.step(0)
+        assert truncated
+
+    def test_create_env_passes_reward_fn(self) -> None:
+        env = create_env(Config(seed=7), reward_fn=lambda s, a, r, s2: 0.0)
+        env.reset()
+        _, reward, _, _, info = env.step(0)
+        assert reward == 0.0
+        assert info["raw_reward"] != 0.0
+
+    def test_create_env_multi_not_implemented(self) -> None:
+        with pytest.raises(NotImplementedError, match="multi-passenger"):
+            create_env(Config(env="multi"))


### PR DESCRIPTION
## Description
Implements BACKLOG T-2.1.1/T-2.1.2/T-2.1.3 (Wave 2): a standardized wrapper around Gymnasium Taxi-v3.

- `gym.make("Taxi-v3", max_episode_steps=N)` verified on gymnasium 1.2.3 to override the spec's default TimeLimit (no double wrapping)
- Seeding: constructor seed applied on first reset only (gymnasium 1.x episodic semantics); explicit `reset(seed=...)` passthrough for the Evaluator's fixed test episodes
- `info["raw_reward"]` always carries the native reward — shaped rewards never leak into benchmark metrics
- `decode_state()` + `TAXI_LOCATIONS` verified against `env.unwrapped.locs`
- `create_env(config)` factory; `env=multi` reserved for feature/multi-passenger

## Tests effectués
18 wrapper tests (types, seeding semantics incl. no-reseed-on-bare-reset, shaping hook, decode round-trip, TimeLimit truncation, render). Local: ruff ✅ black ✅ mypy strict ✅ pytest full suite ✅.

## Issues liées
Closes #6 (T-2.1.1), Closes #10 (T-2.1.2), Closes #32 (T-2.1.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)