### PR TITLE
feat(agent): BaseAgent, exploration strategies and six tabular agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
 - Utilitaires de reproductibilité (`src/utils/seeding.py`) : flux RNG indépendants,
   listes de seeds d'évaluation et de sondes disjointes
 - Configuration par défaut commentée (`configs/default.yaml`)
+- Agents RL tabulaires : `BaseAgent` (contrat terminated-vs-truncated), stratégies
+  d'exploration enfichables (ε-greedy exp/linéaire, Boltzmann, UCB), `TabularAgent`
+  (argmax greedy déterministe, save/load npz), Q-Learning, SARSA, Expected SARSA,
+  Double Q-Learning, Monte Carlo first-visit, BruteForce ; factory `create_agent()`
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ target-version = "py310"
 select = ["E", "W", "F", "I", "N", "UP", "B", "C4", "SIM", "RUF"]
 # E501: line length is enforced by black (strings/comments excepted by convention)
 ignore = ["E501"]
+# RL update rules in docstrings legitimately use mathematical notation.
+allowed-confusables = ["α", "γ", "ε", "π", "−", "×"]
 
 [tool.black]
 line-length = 100

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,1 +1,85 @@
 """RL agents (tabular and deep) implementing the BaseAgent interface."""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Protocol, cast
+
+import numpy as np
+
+from src.agents.base_agent import BaseAgent
+from src.agents.brute_force_agent import BruteForceAgent
+from src.agents.double_q_learning_agent import DoubleQLearningAgent
+from src.agents.expected_sarsa_agent import ExpectedSARSAAgent
+from src.agents.monte_carlo_agent import MonteCarloAgent
+from src.agents.q_learning_agent import QLearningAgent
+from src.agents.sarsa_agent import SARSAAgent
+from src.utils.seeding import spawn_rngs
+
+if TYPE_CHECKING:
+    from src.config import Config
+
+
+class _EnvLike(Protocol):
+    """Anything exposing state/action counts (env wrappers, test stubs)."""
+
+    @property
+    def n_states(self) -> int: ...
+
+    @property
+    def n_actions(self) -> int: ...
+
+
+AGENT_REGISTRY: dict[str, type[BaseAgent]] = {
+    "brute_force": BruteForceAgent,
+    "q_learning": QLearningAgent,
+    "sarsa": SARSAAgent,
+    "expected_sarsa": ExpectedSARSAAgent,
+    "double_q_learning": DoubleQLearningAgent,
+    "monte_carlo": MonteCarloAgent,
+    # "dqn" is resolved lazily in create_agent() to keep torch optional at import time.
+}
+
+
+def create_agent(
+    config: Config,
+    env: _EnvLike,
+    rng: np.random.Generator | None = None,
+    n_episodes: int | None = None,
+) -> BaseAgent:
+    """Instantiate the agent named by ``config.algorithm`` (Factory pattern).
+
+    Args:
+        config: Project configuration (validated: algorithm name is known).
+        env: Environment exposing ``n_states``/``n_actions`` — agents never
+            hardcode Taxi-v3's 500 states.
+        rng: Agent random stream; derived from ``config.seed`` when omitted.
+        n_episodes: Training horizon for decay resolution; defaults to
+            ``config.n_train_episodes``.
+
+    Returns:
+        A ready-to-train agent.
+    """
+    if rng is None:
+        # Stream 0 is reserved for the environment by convention.
+        rng = spawn_rngs(config.seed, 2)[1]
+    if config.algorithm == "dqn":
+        # Lazy import so the tabular stack never pays the torch import cost.
+        module = importlib.import_module("src.agents.dqn.dqn_agent")
+        agent = module.DQNAgent(env.n_states, env.n_actions, config, rng, n_episodes)
+        return cast(BaseAgent, agent)
+    agent_class = AGENT_REGISTRY[config.algorithm]
+    return agent_class(env.n_states, env.n_actions, config, rng, n_episodes)  # type: ignore[call-arg]
+
+
+__all__ = [
+    "AGENT_REGISTRY",
+    "BaseAgent",
+    "BruteForceAgent",
+    "DoubleQLearningAgent",
+    "ExpectedSARSAAgent",
+    "MonteCarloAgent",
+    "QLearningAgent",
+    "SARSAAgent",
+    "create_agent",
+]

--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -1,0 +1,85 @@
+"""Abstract base class defining the contract shared by every agent."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+import numpy as np
+
+from src.config import Config
+
+
+class BaseAgent(ABC):
+    """Common interface for all RL agents (Strategy pattern).
+
+    The training loop contract:
+
+    - ``select_action(state)`` is called on the training path;
+      ``select_action(state, greedy=True)`` on the evaluation path.
+    - ``learn(state, action, reward, next_state, terminated)`` receives
+      ``terminated`` only — never ``terminated or truncated``. An episode cut
+      by a time limit must still bootstrap from the successor state.
+    - ``end_episode()`` is called by the Trainer after every episode
+      (terminated or truncated) so agents can advance schedules and flush
+      episode buffers.
+    """
+
+    name: str = "base"
+
+    def __init__(self, n_states: int, n_actions: int, config: Config, rng: np.random.Generator):
+        self.n_states = n_states
+        self.n_actions = n_actions
+        self.config = config
+        self.rng = rng
+        self.n_episodes_trained = 0
+
+    @abstractmethod
+    def select_action(self, state: int, greedy: bool = False) -> int:
+        """Choose an action for ``state``.
+
+        Args:
+            state: Encoded environment state.
+            greedy: When True, act greedily w.r.t. learned values (evaluation
+                path); no exploration statistics may be updated.
+
+        Returns:
+            The chosen action index.
+        """
+
+    @abstractmethod
+    def learn(
+        self, state: int, action: int, reward: float, next_state: int, terminated: bool
+    ) -> None:
+        """Update knowledge from one transition.
+
+        Args:
+            state: State before the action.
+            action: Action taken.
+            reward: Reward received (possibly shaped).
+            next_state: Successor state.
+            terminated: True only when the MDP reached a terminal state —
+                truncation (time limit) must be passed as False so the update
+                still bootstraps.
+        """
+
+    def end_episode(self) -> None:
+        """Hook called after every episode; advances schedules/counters."""
+        self.n_episodes_trained += 1
+
+    @abstractmethod
+    def save(self, path: str | Path) -> None:
+        """Persist the agent's learned parameters and metadata to ``path``."""
+
+    @abstractmethod
+    def load(self, path: str | Path) -> None:
+        """Restore the agent's learned parameters from ``path``."""
+
+    def memory_bytes(self) -> int:
+        """Approximate memory footprint of learned parameters, in bytes."""
+        return 0
+
+    @property
+    def exploration_level(self) -> float:
+        """Scalar exploration level for logging (epsilon, temperature, ...)."""
+        return 0.0

--- a/src/agents/brute_force_agent.py
+++ b/src/agents/brute_force_agent.py
@@ -1,0 +1,54 @@
+"""Random baseline agent — the comparison point required by the subject."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+
+import numpy as np
+
+from src.agents.base_agent import BaseAgent
+from src.config import Config
+
+
+class BruteForceAgent(BaseAgent):
+    """Uniform-random policy with no learning.
+
+    Serves as the naive brute-force baseline (~350 steps per episode on
+    Taxi-v3 vs ~13 for a tuned agent). ``greedy`` has no effect: a random
+    policy has no greedy counterpart.
+    """
+
+    name = "brute_force"
+
+    def __init__(
+        self,
+        n_states: int,
+        n_actions: int,
+        config: Config,
+        rng: np.random.Generator,
+        n_episodes: int | None = None,
+    ) -> None:
+        super().__init__(n_states, n_actions, config, rng)
+
+    def select_action(self, state: int, greedy: bool = False) -> int:
+        return int(self.rng.integers(self.n_actions))
+
+    def learn(
+        self, state: int, action: int, reward: float, next_state: int, terminated: bool
+    ) -> None:
+        """No-op: the baseline does not learn."""
+
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        metadata = {
+            "algorithm": self.name,
+            "seed": self.config.seed,
+            "saved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+        np.savez_compressed(path, metadata=json.dumps(metadata))
+
+    def load(self, path: str | Path) -> None:
+        """No learned parameters to restore."""

--- a/src/agents/double_q_learning_agent.py
+++ b/src/agents/double_q_learning_agent.py
@@ -1,0 +1,86 @@
+"""Tabular Double Q-Learning (van Hasselt, 2010)."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+
+import numpy as np
+import numpy.typing as npt
+
+from src.agents.tabular_agent import TabularAgent
+
+FloatArray = npt.NDArray[np.float64]
+
+
+class DoubleQLearningAgent(TabularAgent):
+    """Double Q-Learning: two tables to decorrelate selection and evaluation.
+
+    On each transition a fair coin picks the table to update; the argmax is
+    taken in the updated table but *evaluated* in the other one, correcting
+    Q-Learning's max-operator overestimation bias:
+
+    ``Q_A(s,a) += α [r + γ Q_B(s', argmax_a' Q_A(s',a')) − Q_A(s,a)]``
+
+    Action selection uses the sum ``Q_A + Q_B``.
+    """
+
+    name = "double_q_learning"
+
+    def _init_tables(self) -> None:
+        self._qa: FloatArray = np.zeros((self.n_states, self.n_actions), dtype=np.float64)
+        self._qb: FloatArray = np.zeros((self.n_states, self.n_actions), dtype=np.float64)
+
+    @property
+    def q_table(self) -> FloatArray:
+        return self._qa + self._qb
+
+    def q_values(self, state: int) -> FloatArray:
+        row: FloatArray = self._qa[state] + self._qb[state]
+        return row
+
+    def learn(
+        self, state: int, action: int, reward: float, next_state: int, terminated: bool
+    ) -> None:
+        if self.rng.random() < 0.5:
+            primary, other = self._qa, self._qb
+        else:
+            primary, other = self._qb, self._qa
+        target = reward
+        if not terminated:
+            best_next = int(np.argmax(primary[next_state]))
+            target += self.config.gamma * other[next_state, best_next]
+        primary[state, action] += self.config.alpha * (target - primary[state, action])
+
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        metadata = {
+            "algorithm": self.name,
+            "n_states": self.n_states,
+            "n_actions": self.n_actions,
+            "n_episodes_trained": self.n_episodes_trained,
+            "config_hash": self.config.config_hash(),
+            "config": self.config.to_dict(),
+            "saved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+        np.savez_compressed(
+            path, q_table_a=self._qa, q_table_b=self._qb, metadata=json.dumps(metadata)
+        )
+
+    def load(self, path: str | Path) -> None:
+        data = np.load(Path(path), allow_pickle=False)
+        qa, qb = data["q_table_a"], data["q_table_b"]
+        expected = (self.n_states, self.n_actions)
+        if qa.shape != expected or qb.shape != expected:
+            raise ValueError(
+                f"Q-table shapes {qa.shape}/{qb.shape} do not match environment {expected}"
+            )
+        self._qa = qa.astype(np.float64)
+        self._qb = qb.astype(np.float64)
+        metadata = json.loads(str(data["metadata"]))
+        self.n_episodes_trained = int(metadata.get("n_episodes_trained", 0))
+
+    def memory_bytes(self) -> int:
+        return int(self._qa.nbytes + self._qb.nbytes)

--- a/src/agents/expected_sarsa_agent.py
+++ b/src/agents/expected_sarsa_agent.py
@@ -1,0 +1,28 @@
+"""Tabular Expected SARSA (van Seijen et al., 2009)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.agents.tabular_agent import TabularAgent
+
+
+class ExpectedSARSAAgent(TabularAgent):
+    """Expected SARSA: bootstraps from the expectation over the policy.
+
+    ``Q(s,a) += α [r + γ Σ_a' π(a'|s') Q(s',a') − Q(s,a)]`` — replaces
+    SARSA's single sampled a' with its expectation, removing that source of
+    update variance while staying on-policy.
+    """
+
+    name = "expected_sarsa"
+
+    def learn(
+        self, state: int, action: int, reward: float, next_state: int, terminated: bool
+    ) -> None:
+        target = reward
+        if not terminated:
+            q_row = self.q_values(next_state)
+            probs = self.strategy.action_probs(q_row, next_state)
+            target += self.config.gamma * float(np.dot(probs, q_row))
+        self._q[state, action] += self.config.alpha * (target - self._q[state, action])

--- a/src/agents/exploration.py
+++ b/src/agents/exploration.py
@@ -1,0 +1,212 @@
+"""Pluggable exploration strategies shared by all tabular agents (and DQN).
+
+A strategy picks an action from one row of Q-values and owns its own schedule
+state (epsilon, temperature) or statistics (UCB visit counts). Greedy
+evaluation bypasses strategies entirely (see ``TabularAgent.select_action``),
+so evaluation never pollutes UCB counts nor advances decay schedules.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    from src.config import Config
+
+FloatArray = npt.NDArray[np.float64]
+
+
+class ExplorationStrategy(ABC):
+    """Selects actions from Q-values during training. Stateful."""
+
+    def __init__(self, rng: np.random.Generator) -> None:
+        self.rng = rng
+
+    @abstractmethod
+    def select(self, q_row: FloatArray, state: int) -> int:
+        """Pick an action for ``state`` given its row of Q-values."""
+
+    @abstractmethod
+    def action_probs(self, q_row: FloatArray, state: int) -> FloatArray:
+        """Return π(a|s) under this strategy (used by Expected SARSA)."""
+
+    def decay(self) -> None:  # noqa: B027 — optional hook, deliberate no-op default
+        """Advance the schedule by one episode. Default: no schedule."""
+
+    @property
+    def epsilon_like(self) -> float:
+        """Scalar summarising the current exploration level, for logging."""
+        return 0.0
+
+    @staticmethod
+    def _random_tie_argmax(q_row: FloatArray, rng: np.random.Generator) -> int:
+        """Argmax with uniform random tie-breaking (training path only)."""
+        best = np.flatnonzero(q_row == q_row.max())
+        return int(best[rng.integers(len(best))])
+
+
+class EpsilonGreedy(ExplorationStrategy):
+    """ε-greedy with exponential or linear per-episode decay."""
+
+    def __init__(
+        self,
+        rng: np.random.Generator,
+        epsilon: float = 1.0,
+        epsilon_min: float = 0.01,
+        decay_rate: float = 0.9995,
+        decay_type: str = "exp",
+    ) -> None:
+        super().__init__(rng)
+        self.epsilon = epsilon
+        self.epsilon_min = epsilon_min
+        self.decay_rate = decay_rate
+        self.decay_type = decay_type
+
+    def select(self, q_row: FloatArray, state: int) -> int:
+        if self.rng.random() < self.epsilon:
+            return int(self.rng.integers(len(q_row)))
+        return self._random_tie_argmax(q_row, self.rng)
+
+    def action_probs(self, q_row: FloatArray, state: int) -> FloatArray:
+        n_actions = len(q_row)
+        probs = np.full(n_actions, self.epsilon / n_actions, dtype=np.float64)
+        best = np.flatnonzero(q_row == q_row.max())
+        probs[best] += (1.0 - self.epsilon) / len(best)
+        return probs
+
+    def decay(self) -> None:
+        if self.decay_type == "exp":
+            self.epsilon = max(self.epsilon_min, self.epsilon * self.decay_rate)
+        else:
+            self.epsilon = max(self.epsilon_min, self.epsilon - self.decay_rate)
+
+    @property
+    def epsilon_like(self) -> float:
+        return self.epsilon
+
+
+class Boltzmann(ExplorationStrategy):
+    """Softmax (Boltzmann) exploration with temperature decay."""
+
+    def __init__(
+        self,
+        rng: np.random.Generator,
+        temperature: float = 1.0,
+        temperature_min: float = 0.05,
+        decay_rate: float = 0.999,
+    ) -> None:
+        super().__init__(rng)
+        self.temperature = temperature
+        self.temperature_min = temperature_min
+        self.decay_rate = decay_rate
+
+    def select(self, q_row: FloatArray, state: int) -> int:
+        return int(self.rng.choice(len(q_row), p=self.action_probs(q_row, state)))
+
+    def action_probs(self, q_row: FloatArray, state: int) -> FloatArray:
+        # Max-subtraction for numerical stability: softmax is shift-invariant.
+        logits = (q_row - q_row.max()) / self.temperature
+        exp = np.exp(logits)
+        probs: FloatArray = exp / exp.sum()
+        return probs
+
+    def decay(self) -> None:
+        self.temperature = max(self.temperature_min, self.temperature * self.decay_rate)
+
+    @property
+    def epsilon_like(self) -> float:
+        return self.temperature
+
+
+class UCB(ExplorationStrategy):
+    """Upper Confidence Bound exploration over per-(state, action) counts.
+
+    Untried actions in a state always take priority; afterwards actions are
+    ranked by ``Q(s, a) + c * sqrt(ln t / N(s, a))`` where ``t`` is the total
+    number of selections in ``s``. Counts live inside the strategy and are
+    only updated on the training path.
+    """
+
+    def __init__(
+        self, rng: np.random.Generator, n_states: int, n_actions: int, c: float = 2.0
+    ) -> None:
+        super().__init__(rng)
+        self.c = c
+        self.counts: npt.NDArray[np.int64] = np.zeros((n_states, n_actions), dtype=np.int64)
+
+    def select(self, q_row: FloatArray, state: int) -> int:
+        counts_row = self.counts[state]
+        untried = np.flatnonzero(counts_row == 0)
+        if len(untried) > 0:
+            action = int(untried[self.rng.integers(len(untried))])
+        else:
+            t = float(counts_row.sum())
+            scores = q_row + self.c * np.sqrt(np.log(t) / counts_row)
+            action = self._random_tie_argmax(scores, self.rng)
+        self.counts[state, action] += 1
+        return action
+
+    def action_probs(self, q_row: FloatArray, state: int) -> FloatArray:
+        # UCB is deterministic given its counts: one-hot on the current choice
+        # (without recording a visit).
+        counts_row = self.counts[state]
+        untried = np.flatnonzero(counts_row == 0)
+        if len(untried) > 0:
+            probs = np.zeros(len(q_row), dtype=np.float64)
+            probs[untried] = 1.0 / len(untried)
+            return probs
+        t = float(counts_row.sum())
+        scores = q_row + self.c * np.sqrt(np.log(t) / counts_row)
+        probs = np.zeros(len(q_row), dtype=np.float64)
+        probs[int(np.argmax(scores))] = 1.0
+        return probs
+
+
+EXPLORATION_REGISTRY: dict[str, type[ExplorationStrategy]] = {
+    "epsilon_greedy": EpsilonGreedy,
+    "boltzmann": Boltzmann,
+    "ucb": UCB,
+}
+
+
+def create_exploration(
+    config: Config,
+    n_states: int,
+    n_actions: int,
+    rng: np.random.Generator,
+    n_episodes: int | None = None,
+) -> ExplorationStrategy:
+    """Build the exploration strategy described by ``config``.
+
+    Args:
+        config: Project configuration.
+        n_states: Environment state count (UCB counts shape).
+        n_actions: Environment action count.
+        rng: Random generator owned by the calling agent.
+        n_episodes: Training horizon used to resolve ``config.decay_frac``;
+            defaults to ``config.n_train_episodes``.
+
+    Returns:
+        A ready-to-use ExplorationStrategy.
+    """
+    horizon = n_episodes if n_episodes is not None else config.n_train_episodes
+    if config.exploration == "epsilon_greedy":
+        return EpsilonGreedy(
+            rng,
+            epsilon=config.epsilon,
+            epsilon_min=config.epsilon_min,
+            decay_rate=config.effective_decay(horizon),
+            decay_type=config.decay_type,
+        )
+    if config.exploration == "boltzmann":
+        return Boltzmann(
+            rng,
+            temperature=config.temperature,
+            temperature_min=config.temperature_min,
+            decay_rate=config.temperature_decay,
+        )
+    return UCB(rng, n_states=n_states, n_actions=n_actions, c=config.ucb_c)

--- a/src/agents/monte_carlo_agent.py
+++ b/src/agents/monte_carlo_agent.py
@@ -1,0 +1,64 @@
+"""Tabular first-visit Monte Carlo control."""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+from src.agents.tabular_agent import TabularAgent
+from src.config import Config
+
+
+class MonteCarloAgent(TabularAgent):
+    """First-visit Monte Carlo control with incremental-mean updates.
+
+    Transitions are buffered during the episode; ``end_episode()`` walks the
+    trajectory backwards accumulating the discounted return G and updates
+    ``Q(s,a)`` towards G on the *first* visit of each (s, a) pair:
+    ``Q(s,a) += (G − Q(s,a)) / N(s,a)``.
+
+    Updates happen on episode end regardless of termination type; truncated
+    episodes contribute their (biased) truncated return, a known limitation
+    of Monte Carlo methods on time-limited environments.
+    """
+
+    name = "monte_carlo"
+
+    def __init__(
+        self,
+        n_states: int,
+        n_actions: int,
+        config: Config,
+        rng: np.random.Generator,
+        n_episodes: int | None = None,
+    ) -> None:
+        super().__init__(n_states, n_actions, config, rng, n_episodes)
+        self._counts: npt.NDArray[np.int64] = np.zeros((n_states, n_actions), dtype=np.int64)
+        self._episode: list[tuple[int, int, float]] = []
+
+    def learn(
+        self, state: int, action: int, reward: float, next_state: int, terminated: bool
+    ) -> None:
+        self._episode.append((state, action, reward))
+
+    def end_episode(self) -> None:
+        if self._episode:
+            self._update_from_episode()
+            self._episode.clear()
+        super().end_episode()
+
+    def _update_from_episode(self) -> None:
+        first_visit: dict[tuple[int, int], int] = {}
+        for t, (state, action, _) in enumerate(self._episode):
+            first_visit.setdefault((state, action), t)
+
+        g = 0.0
+        for t in range(len(self._episode) - 1, -1, -1):
+            state, action, reward = self._episode[t]
+            g = self.config.gamma * g + reward
+            if first_visit[(state, action)] == t:
+                self._counts[state, action] += 1
+                self._q[state, action] += (g - self._q[state, action]) / self._counts[state, action]
+
+    def memory_bytes(self) -> int:
+        return int(self._q.nbytes + self._counts.nbytes)

--- a/src/agents/q_learning_agent.py
+++ b/src/agents/q_learning_agent.py
@@ -1,0 +1,23 @@
+"""Tabular Q-Learning (Watkins, 1989) — off-policy TD control."""
+
+from __future__ import annotations
+
+from src.agents.tabular_agent import TabularAgent
+
+
+class QLearningAgent(TabularAgent):
+    """Q-Learning: ``Q(s,a) += α [r + γ max_a' Q(s',a') − Q(s,a)]``.
+
+    Off-policy: the update bootstraps from the best next action regardless of
+    the action actually taken by the exploration policy.
+    """
+
+    name = "q_learning"
+
+    def learn(
+        self, state: int, action: int, reward: float, next_state: int, terminated: bool
+    ) -> None:
+        target = reward
+        if not terminated:
+            target += self.config.gamma * float(self._q[next_state].max())
+        self._q[state, action] += self.config.alpha * (target - self._q[state, action])

--- a/src/agents/sarsa_agent.py
+++ b/src/agents/sarsa_agent.py
@@ -1,0 +1,53 @@
+"""Tabular SARSA (Rummery & Niranjan, 1994) — on-policy TD control."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from src.agents.tabular_agent import TabularAgent
+from src.config import Config
+
+
+class SARSAAgent(TabularAgent):
+    """SARSA: ``Q(s,a) += α [r + γ Q(s',a') − Q(s,a)]`` with a' actually taken.
+
+    On-policy correctness requires that the a' used in the update is the very
+    action executed at the next step: ``learn()`` draws a' from the
+    exploration strategy, uses it for the update, and caches it so the next
+    ``select_action(s')`` call returns it instead of re-sampling.
+    """
+
+    name = "sarsa"
+
+    def __init__(
+        self,
+        n_states: int,
+        n_actions: int,
+        config: Config,
+        rng: np.random.Generator,
+        n_episodes: int | None = None,
+    ) -> None:
+        super().__init__(n_states, n_actions, config, rng, n_episodes)
+        self._next_action: int | None = None
+
+    def select_action(self, state: int, greedy: bool = False) -> int:
+        if greedy:
+            return super().select_action(state, greedy=True)
+        if self._next_action is not None:
+            action, self._next_action = self._next_action, None
+            return action
+        return super().select_action(state)
+
+    def learn(
+        self, state: int, action: int, reward: float, next_state: int, terminated: bool
+    ) -> None:
+        target = reward
+        if not terminated:
+            next_action = self.strategy.select(self.q_values(next_state), next_state)
+            self._next_action = next_action
+            target += self.config.gamma * self._q[next_state, next_action]
+        self._q[state, action] += self.config.alpha * (target - self._q[state, action])
+
+    def end_episode(self) -> None:
+        super().end_episode()
+        self._next_action = None

--- a/src/agents/tabular_agent.py
+++ b/src/agents/tabular_agent.py
@@ -1,0 +1,101 @@
+"""Shared plumbing for tabular agents: Q-table storage and exploration."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+
+import numpy as np
+import numpy.typing as npt
+
+from src.agents.base_agent import BaseAgent
+from src.agents.exploration import create_exploration
+from src.config import Config
+
+FloatArray = npt.NDArray[np.float64]
+
+
+class TabularAgent(BaseAgent):
+    """Base class for agents backed by an in-memory Q-table.
+
+    Subclasses implement ``learn()`` only. Greedy action selection uses a
+    deterministic argmax (smallest index on ties) so that evaluation results
+    are strictly comparable across agents; the training path delegates to the
+    configured exploration strategy (random tie-breaking).
+    """
+
+    name = "tabular"
+
+    def __init__(
+        self,
+        n_states: int,
+        n_actions: int,
+        config: Config,
+        rng: np.random.Generator,
+        n_episodes: int | None = None,
+    ) -> None:
+        super().__init__(n_states, n_actions, config, rng)
+        self._init_tables()
+        self.strategy = create_exploration(config, n_states, n_actions, rng, n_episodes)
+
+    # ------------------------------------------------------------------ storage
+
+    def _init_tables(self) -> None:
+        self._q: FloatArray = np.zeros((self.n_states, self.n_actions), dtype=np.float64)
+
+    @property
+    def q_table(self) -> FloatArray:
+        """Full Q-table view (used by save/heatmaps); may be derived."""
+        return self._q
+
+    def q_values(self, state: int) -> FloatArray:
+        """Row of Q-values used for action selection in ``state``."""
+        row: FloatArray = self._q[state]
+        return row
+
+    # ------------------------------------------------------------------ actions
+
+    def select_action(self, state: int, greedy: bool = False) -> int:
+        if greedy:
+            return int(np.argmax(self.q_values(state)))
+        return self.strategy.select(self.q_values(state), state)
+
+    def end_episode(self) -> None:
+        super().end_episode()
+        self.strategy.decay()
+
+    # ------------------------------------------------------------------ persistence
+
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        metadata = {
+            "algorithm": self.name,
+            "n_states": self.n_states,
+            "n_actions": self.n_actions,
+            "n_episodes_trained": self.n_episodes_trained,
+            "config_hash": self.config.config_hash(),
+            "config": self.config.to_dict(),
+            "saved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+        np.savez_compressed(path, q_table=self.q_table, metadata=json.dumps(metadata))
+
+    def load(self, path: str | Path) -> None:
+        data = np.load(Path(path), allow_pickle=False)
+        q_table = data["q_table"]
+        if q_table.shape != (self.n_states, self.n_actions):
+            raise ValueError(
+                f"Q-table shape {q_table.shape} does not match environment "
+                f"({self.n_states}, {self.n_actions})"
+            )
+        self._q = q_table.astype(np.float64)
+        metadata = json.loads(str(data["metadata"]))
+        self.n_episodes_trained = int(metadata.get("n_episodes_trained", 0))
+
+    def memory_bytes(self) -> int:
+        return int(self._q.nbytes)
+
+    @property
+    def exploration_level(self) -> float:
+        return self.strategy.epsilon_like

--- a/tests/agents/test_agents_tabular.py
+++ b/tests/agents/test_agents_tabular.py
@@ -1,0 +1,215 @@
+"""Hand-computed update tests for every tabular agent + shared contracts."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.agents import AGENT_REGISTRY, create_agent
+from src.agents.base_agent import BaseAgent
+from src.agents.brute_force_agent import BruteForceAgent
+from src.agents.double_q_learning_agent import DoubleQLearningAgent
+from src.agents.expected_sarsa_agent import ExpectedSARSAAgent
+from src.agents.monte_carlo_agent import MonteCarloAgent
+from src.agents.q_learning_agent import QLearningAgent
+from src.agents.sarsa_agent import SARSAAgent
+from src.config import Config
+
+N_STATES, N_ACTIONS = 10, 4
+LEARN_CONFIG = Config(alpha=0.5, gamma=0.9, epsilon=0.0)  # greedy strategy for determinism
+
+
+def make(cls: type, config: Config | None = None, seed: int = 7) -> BaseAgent:
+    agent: BaseAgent = cls(N_STATES, N_ACTIONS, config or LEARN_CONFIG, np.random.default_rng(seed))
+    return agent
+
+
+class TestBaseContracts:
+    def test_base_agent_is_abstract(self, config: Config, rng: np.random.Generator) -> None:
+        with pytest.raises(TypeError):
+            BaseAgent(N_STATES, N_ACTIONS, config, rng)  # type: ignore[abstract]
+
+    def test_registry_contains_all_tabular_agents(self) -> None:
+        assert set(AGENT_REGISTRY) == {
+            "brute_force",
+            "q_learning",
+            "sarsa",
+            "expected_sarsa",
+            "double_q_learning",
+            "monte_carlo",
+        }
+
+    def test_create_agent_uses_env_dimensions(self, fake_env: object) -> None:
+        agent = create_agent(Config(algorithm="q_learning"), fake_env)
+        assert isinstance(agent, QLearningAgent)
+        assert agent.q_table.shape == (fake_env.n_states, fake_env.n_actions)
+
+    def test_create_agent_dqn_not_yet_available(self, fake_env: object) -> None:
+        with pytest.raises(ImportError):
+            create_agent(Config(algorithm="dqn"), fake_env)
+
+    @pytest.mark.parametrize("name", sorted(AGENT_REGISTRY))
+    def test_select_action_in_range(self, name: str, fake_env: object) -> None:
+        agent = create_agent(Config(algorithm=name), fake_env)
+        for greedy in (False, True):
+            action = agent.select_action(0, greedy=greedy)
+            assert 0 <= action < fake_env.n_actions
+
+    @pytest.mark.parametrize("name", sorted(set(AGENT_REGISTRY) - {"brute_force"}))
+    def test_save_load_round_trip(self, name: str, tmp_path: Path) -> None:
+        config = Config(algorithm=name, epsilon=1.0)
+        agent = make(AGENT_REGISTRY[name], config)
+        # random-ish training to fill tables
+        for _ in range(3):
+            for s in range(N_STATES - 1):
+                agent.learn(s, agent.select_action(s), -1.0, s + 1, s == N_STATES - 2)
+            agent.end_episode()
+        path = tmp_path / f"{name}.npz"
+        agent.save(path)
+        clone = make(AGENT_REGISTRY[name], config)
+        clone.load(path)
+        assert np.array_equal(agent.q_table, clone.q_table)  # type: ignore[attr-defined]
+        assert clone.n_episodes_trained == agent.n_episodes_trained
+
+    def test_load_shape_mismatch_raises(self, tmp_path: Path) -> None:
+        agent = make(QLearningAgent)
+        path = tmp_path / "q.npz"
+        agent.save(path)
+        small = QLearningAgent(5, N_ACTIONS, LEARN_CONFIG, np.random.default_rng(0))
+        with pytest.raises(ValueError, match="shape"):
+            small.load(path)
+
+    def test_reproducibility_same_seed_same_tables(self, fake_env: object) -> None:
+        config = Config(algorithm="q_learning", epsilon=1.0)
+        tables = []
+        for _ in range(2):
+            agent = create_agent(config, fake_env)
+            for s in range(fake_env.n_states - 1):
+                a = agent.select_action(s)
+                agent.learn(s, a, float(a), s + 1, False)
+            agent.end_episode()
+            tables.append(agent.q_table.copy())  # type: ignore[attr-defined]
+        assert np.array_equal(tables[0], tables[1])
+
+
+class TestBruteForce:
+    def test_actions_cover_space_and_learn_is_noop(self) -> None:
+        agent = make(BruteForceAgent)
+        actions = {agent.select_action(0) for _ in range(200)}
+        assert actions == set(range(N_ACTIONS))
+        agent.learn(0, 0, 10.0, 1, False)  # must not raise nor store anything
+        assert agent.memory_bytes() == 0
+
+
+class TestQLearning:
+    def test_hand_computed_update(self) -> None:
+        agent = make(QLearningAgent)
+        agent._q[3] = np.array([1.0, 7.0, 2.0, 0.0])
+        agent.learn(state=0, action=1, reward=10.0, next_state=3, terminated=False)
+        # target = 10 + 0.9 * 7 = 16.3 ; q = 0 + 0.5 * 16.3 = 8.15
+        assert agent._q[0, 1] == pytest.approx(8.15)
+
+    def test_terminal_update_ignores_next_state(self) -> None:
+        agent = make(QLearningAgent)
+        agent._q[3] = np.array([100.0, 100.0, 100.0, 100.0])
+        agent.learn(0, 2, 20.0, 3, terminated=True)
+        assert agent._q[0, 2] == pytest.approx(10.0)  # 0 + 0.5 * 20
+
+
+class TestSARSA:
+    def test_update_uses_and_caches_next_action(self) -> None:
+        agent = make(SARSAAgent)
+        agent._q[3] = np.array([1.0, 7.0, 2.0, 0.0])
+        agent.learn(0, 1, 10.0, 3, terminated=False)
+        # greedy strategy (eps=0) picks a'=1 → target = 10 + 0.9*7 = 16.3
+        assert agent._q[0, 1] == pytest.approx(8.15)
+        # the very next on-policy selection in s'=3 must return the cached a'
+        assert agent.select_action(3) == 1
+        # cache is one-shot
+        agent._q[3] = np.array([9.0, 0.0, 0.0, 0.0])
+        assert agent.select_action(3) == 0
+
+    def test_end_episode_clears_cache(self) -> None:
+        agent = make(SARSAAgent)
+        agent._q[3] = np.array([0.0, 5.0, 0.0, 0.0])
+        agent.learn(0, 0, 0.0, 3, terminated=False)
+        agent.end_episode()
+        agent._q[3] = np.array([9.0, 0.0, 0.0, 0.0])
+        assert agent.select_action(3) == 0  # fresh draw, not stale cache
+
+
+class TestExpectedSARSA:
+    def test_hand_computed_expectation(self) -> None:
+        config = Config(alpha=0.5, gamma=0.9, epsilon=0.4)
+        agent = make(ExpectedSARSAAgent, config)
+        agent._q[3] = np.array([0.0, 8.0, 4.0, 0.0])
+        agent.learn(0, 1, 10.0, 3, terminated=False)
+        # π(a|3): eps/4 = 0.1 each + 0.6 on argmax (a=1, unique)
+        # E[Q] = 0.1*0 + 0.7*8 + 0.1*4 + 0.1*0 = 6.0 ; target = 10 + 0.9*6 = 15.4
+        assert agent._q[0, 1] == pytest.approx(0.5 * 15.4)
+
+
+class TestDoubleQLearning:
+    def test_cross_table_update_matches_coin(self) -> None:
+        agent = make(DoubleQLearningAgent, seed=11)
+        peek = np.random.default_rng(11)
+        agent._qa[3] = np.array([0.0, 6.0, 0.0, 0.0])  # argmax A in s'=3 → a'=1
+        agent._qb[3] = np.array([0.0, 2.0, 0.0, 0.0])  # Q_B(3,1) = 2
+        coin_updates_a = peek.random() < 0.5
+        agent.learn(0, 0, 1.0, 3, terminated=False)
+        if coin_updates_a:
+            # target = 1 + 0.9 * Q_B(3, argmax Q_A(3)) = 1 + 0.9*2 = 2.8
+            assert agent._qa[0, 0] == pytest.approx(0.5 * 2.8)
+            assert agent._qb[0, 0] == 0.0
+        else:
+            # target = 1 + 0.9 * Q_A(3, argmax Q_B(3)) = 1 + 0.9*6 = 6.4
+            assert agent._qb[0, 0] == pytest.approx(0.5 * 6.4)
+            assert agent._qa[0, 0] == 0.0
+
+    def test_selection_uses_sum_of_tables(self) -> None:
+        agent = make(DoubleQLearningAgent)
+        agent._qa[0] = np.array([1.0, 0.0, 0.0, 0.0])
+        agent._qb[0] = np.array([0.0, 0.0, 2.0, 0.0])
+        assert agent.select_action(0, greedy=True) == 2
+        assert agent.memory_bytes() == 2 * agent._qa.nbytes
+
+
+class TestMonteCarlo:
+    def test_first_visit_returns_on_synthetic_episode(self) -> None:
+        config = Config(alpha=0.5, gamma=0.5, epsilon=0.0)
+        agent = make(MonteCarloAgent, config)
+        agent.learn(0, 0, 0.0, 1, False)
+        agent.learn(1, 1, 1.0, 2, True)
+        assert agent._q[0, 0] == 0.0  # nothing updated before episode end
+        agent.end_episode()
+        # G(s1,a1) = 1 ; G(s0,a0) = 0 + 0.5*1 = 0.5 ; counts = 1 → exact means
+        assert agent._q[1, 1] == pytest.approx(1.0)
+        assert agent._q[0, 0] == pytest.approx(0.5)
+
+    def test_first_visit_counts_repeat_pairs_once(self) -> None:
+        config = Config(gamma=1.0, epsilon=0.0)
+        agent = make(MonteCarloAgent, config)
+        # (0,0) visited twice: returns from first visit = 3, from second = 1
+        agent.learn(0, 0, 1.0, 1, False)
+        agent.learn(1, 0, 1.0, 0, False)
+        agent.learn(0, 0, 1.0, 2, True)
+        agent.end_episode()
+        assert agent._counts[0, 0] == 1
+        assert agent._q[0, 0] == pytest.approx(3.0)  # first-visit return only
+
+    def test_truncated_episode_flushed_by_end_episode(self) -> None:
+        agent = make(MonteCarloAgent, Config(gamma=1.0, epsilon=0.0))
+        agent.learn(0, 0, 5.0, 1, False)  # episode truncated: terminated stays False
+        agent.end_episode()
+        assert agent._q[0, 0] == pytest.approx(5.0)
+        assert not agent._episode  # buffer cleared
+
+
+class TestExplorationDecayWiring:
+    def test_end_episode_decays_epsilon(self) -> None:
+        config = Config(epsilon=1.0, epsilon_min=0.0, epsilon_decay=0.5)
+        agent = make(QLearningAgent, config)
+        assert agent.exploration_level == 1.0
+        agent.end_episode()
+        assert agent.exploration_level == 0.5
+        assert agent.n_episodes_trained == 1

--- a/tests/agents/test_exploration.py
+++ b/tests/agents/test_exploration.py
@@ -1,0 +1,119 @@
+"""Tests for exploration strategies: selection laws, decay, probabilities."""
+
+import numpy as np
+import pytest
+
+from src.agents.exploration import UCB, Boltzmann, EpsilonGreedy, create_exploration
+from src.config import Config
+
+Q_ROW = np.array([0.0, 5.0, 1.0, 5.0], dtype=np.float64)  # ties on actions 1 and 3
+
+
+class TestEpsilonGreedy:
+    def test_epsilon_zero_is_pure_argmax(self, rng: np.random.Generator) -> None:
+        strategy = EpsilonGreedy(rng, epsilon=0.0)
+        actions = {strategy.select(Q_ROW, 0) for _ in range(50)}
+        assert actions <= {1, 3}  # only maximal actions (random tie-breaking)
+
+    def test_epsilon_one_covers_all_actions(self, rng: np.random.Generator) -> None:
+        strategy = EpsilonGreedy(rng, epsilon=1.0)
+        actions = {strategy.select(Q_ROW, 0) for _ in range(200)}
+        assert actions == {0, 1, 2, 3}
+
+    def test_exp_decay_floors_at_min(self, rng: np.random.Generator) -> None:
+        strategy = EpsilonGreedy(rng, epsilon=1.0, epsilon_min=0.5, decay_rate=0.1)
+        for _ in range(10):
+            strategy.decay()
+        assert strategy.epsilon == 0.5
+
+    def test_linear_decay(self, rng: np.random.Generator) -> None:
+        strategy = EpsilonGreedy(
+            rng, epsilon=1.0, epsilon_min=0.0, decay_rate=0.25, decay_type="linear"
+        )
+        strategy.decay()
+        assert strategy.epsilon == pytest.approx(0.75)
+
+    def test_action_probs_sum_to_one_and_favour_ties(self, rng: np.random.Generator) -> None:
+        strategy = EpsilonGreedy(rng, epsilon=0.4)
+        probs = strategy.action_probs(Q_ROW, 0)
+        assert probs.sum() == pytest.approx(1.0)
+        assert probs[1] == pytest.approx(0.1 + 0.6 / 2)  # eps/4 + (1-eps)/2 ties
+        assert probs[0] == pytest.approx(0.1)
+
+    def test_epsilon_like_reports_epsilon(self, rng: np.random.Generator) -> None:
+        assert EpsilonGreedy(rng, epsilon=0.7).epsilon_like == 0.7
+
+
+class TestBoltzmann:
+    def test_probs_monotone_in_q(self, rng: np.random.Generator) -> None:
+        strategy = Boltzmann(rng, temperature=1.0)
+        probs = strategy.action_probs(Q_ROW, 0)
+        assert probs.sum() == pytest.approx(1.0)
+        assert probs[1] > probs[2] > probs[0]
+        assert probs[1] == pytest.approx(probs[3])
+
+    def test_low_temperature_approaches_greedy(self, rng: np.random.Generator) -> None:
+        strategy = Boltzmann(rng, temperature=0.01)
+        probs = strategy.action_probs(Q_ROW, 0)
+        assert probs[1] + probs[3] == pytest.approx(1.0, abs=1e-6)
+
+    def test_temperature_decay_floors(self, rng: np.random.Generator) -> None:
+        strategy = Boltzmann(rng, temperature=1.0, temperature_min=0.5, decay_rate=0.1)
+        for _ in range(10):
+            strategy.decay()
+        assert strategy.temperature == 0.5
+
+    def test_numerical_stability_with_large_q(self, rng: np.random.Generator) -> None:
+        huge = np.array([1e8, 1e8 + 1, 0.0], dtype=np.float64)
+        probs = Boltzmann(rng, temperature=1.0).action_probs(huge, 0)
+        assert np.isfinite(probs).all()
+        assert probs.sum() == pytest.approx(1.0)
+
+
+class TestUCB:
+    def test_tries_every_untried_action_first(self, rng: np.random.Generator) -> None:
+        strategy = UCB(rng, n_states=3, n_actions=4, c=2.0)
+        first_four = {strategy.select(Q_ROW, state=1) for _ in range(4)}
+        assert first_four == {0, 1, 2, 3}
+        assert strategy.counts[1].sum() == 4
+        assert strategy.counts[0].sum() == 0  # other states untouched
+
+    def test_counts_only_grow_via_select(self, rng: np.random.Generator) -> None:
+        strategy = UCB(rng, n_states=2, n_actions=4)
+        strategy.action_probs(Q_ROW, 0)
+        assert strategy.counts.sum() == 0
+
+    def test_prefers_high_q_when_counts_equal(self, rng: np.random.Generator) -> None:
+        strategy = UCB(rng, n_states=1, n_actions=4, c=0.5)
+        for _ in range(4):
+            strategy.select(Q_ROW, 0)
+        picks = [strategy.select(Q_ROW, 0) for _ in range(20)]
+        assert set(picks) <= {1, 3}
+
+    def test_action_probs_one_hot_after_warmup(self, rng: np.random.Generator) -> None:
+        strategy = UCB(rng, n_states=1, n_actions=4)
+        for _ in range(4):
+            strategy.select(Q_ROW, 0)
+        probs = strategy.action_probs(Q_ROW, 0)
+        assert probs.sum() == pytest.approx(1.0)
+        assert (probs == 1.0).sum() == 1
+
+
+class TestFactory:
+    def test_builds_each_kind(self, rng: np.random.Generator) -> None:
+        for name, cls in [
+            ("epsilon_greedy", EpsilonGreedy),
+            ("boltzmann", Boltzmann),
+            ("ucb", UCB),
+        ]:
+            config = Config(exploration=name)
+            assert isinstance(create_exploration(config, 10, 4, rng), cls)
+
+    def test_decay_frac_resolved_through_factory(self, rng: np.random.Generator) -> None:
+        config = Config(decay_frac=0.5, epsilon=1.0, epsilon_min=0.01)
+        strategy = create_exploration(config, 10, 4, rng, n_episodes=1000)
+        assert isinstance(strategy, EpsilonGreedy)
+        # after 500 decays epsilon should hit epsilon_min
+        for _ in range(500):
+            strategy.decay()
+        assert strategy.epsilon == pytest.approx(0.01, rel=1e-6)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+from src.config import Config
+
+
+@dataclass(frozen=True)
+class FakeEnvSpec:
+    """Minimal stand-in exposing state/action counts (no gymnasium needed)."""
+
+    n_states: int = 10
+    n_actions: int = 4
+
+
+@pytest.fixture
+def fake_env() -> FakeEnvSpec:
+    return FakeEnvSpec()
+
+
+@pytest.fixture
+def config() -> Config:
+    return Config()
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    return np.random.default_rng(123)


### PR DESCRIPTION
## Description
Implements BACKLOG Waves 2-3 agent tickets plus the extra-scope algorithms:

- **BaseAgent** ABC: `select_action(state, greedy=)`, `learn(s, a, r, s', terminated)` — the trainer passes `terminated` only (time-limit truncation still bootstraps: classic tabular/DQN correctness bug avoided by contract), `end_episode()` hook
- **Exploration strategies** (Strategy pattern, shared by all tabular agents): ε-greedy (exp/linear decay, `decay_frac` horizon-fraction parameterization), Boltzmann (max-subtracted softmax), UCB (internal per-(s,a) counts, untried-first; evaluation never touches counts)
- **Agents**: BruteForce, Q-Learning, SARSA (update uses the exact action executed next — cached on-policy draw), Expected SARSA, Double Q-Learning (cross-table target, selection on sum), first-visit Monte Carlo (episode buffer flushed in `end_episode`, truncation-safe)
- **Factory** `create_agent(config, env)` sizes Q-tables from `env.n_states/n_actions` (multi-passenger-ready, nothing hardcodes 500); DQN entry resolved lazily for feature/dqn

**Sanity check**: Q-Learning (α=0.15, γ=0.99, decay_frac=0.6), 15 000 épisodes en 10.9 s → éval greedy sur 100 épisodes à seeds fixes : reward moyen **8.05**, steps moyen **12.95**, succès **100 %** (cibles CADRAGE §6.1 atteintes).

## Tests effectués
45 nouveaux tests : mises à jour calculées à la main pour chacun des 6 algorithmes (dont l'espérance Expected SARSA et la pièce Double Q prédite par clonage du RNG), lois d'exploration, save/load round-trip, reproductibilité bit-à-bit à seed égal. Local : ruff ✅ black ✅ mypy strict ✅ pytest 81/81 ✅.

## Issues liées
Closes #7 (T-3.1.1), Closes #9 (T-3.1.2), Closes #22 (T-3.1.3), Closes #11 (T-3.2.1), Closes #20 (T-3.2.2), Closes #21 (T-3.2.3), Closes #12 (T-3.5.1), Closes #49 (T-3.4.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)