### PR TITLE
feat(training): Trainer, callbacks, Evaluator and metrics

### DIFF
--- a/src/evaluation/evaluator.py
+++ b/src/evaluation/evaluator.py
@@ -1,0 +1,118 @@
+"""Greedy evaluation of trained agents on fixed episode sets."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from src.evaluation.metrics import EvalResults, compute_eval_results
+
+if TYPE_CHECKING:
+    from src.agents.base_agent import BaseAgent
+    from src.environments.taxi_wrapper import TaxiEnvWrapper
+
+ACTION_NAMES = ("South", "North", "East", "West", "Pickup", "Dropoff")
+
+
+class Evaluator:
+    """Runs greedy test episodes with per-episode explicit seeding.
+
+    Every episode ``i`` resets the environment with ``seeds[i]``, so all
+    agents are evaluated on exactly the same start states — the precondition
+    for fair pairwise comparisons and the statistical protocol.
+    """
+
+    def __init__(self, env: TaxiEnvWrapper, seeds: list[int] | None = None) -> None:
+        self.env = env
+        self.seeds = seeds
+
+    def _episode_seed(self, index: int) -> int | None:
+        if self.seeds is None:
+            return None
+        return self.seeds[index % len(self.seeds)]
+
+    def evaluate(self, agent: BaseAgent, n_episodes: int) -> EvalResults:
+        """Evaluate ``agent`` greedily (no learning, no exploration).
+
+        Args:
+            agent: Trained agent; ``select_action(..., greedy=True)`` is used.
+            n_episodes: Number of test episodes.
+
+        Returns:
+            Aggregated EvalResults over the ``n_episodes`` episodes.
+        """
+        rewards: list[float] = []
+        steps: list[int] = []
+        successes: list[bool] = []
+        illegal: list[int] = []
+        durations: list[float] = []
+        for i in range(n_episodes):
+            t0 = time.perf_counter()
+            state, _ = self.env.reset(seed=self._episode_seed(i))
+            total_raw = 0.0
+            n_steps = 0
+            n_illegal = 0
+            terminated = truncated = False
+            while not (terminated or truncated):
+                action = agent.select_action(state, greedy=True)
+                state, _, terminated, truncated, info = self.env.step(action)
+                raw = float(info["raw_reward"])
+                total_raw += raw
+                n_illegal += raw == -10.0
+                n_steps += 1
+            durations.append(time.perf_counter() - t0)
+            rewards.append(total_raw)
+            steps.append(n_steps)
+            successes.append(terminated)
+            illegal.append(n_illegal)
+        return compute_eval_results(rewards, steps, successes, illegal, durations)
+
+    def display_episodes(
+        self,
+        agent: BaseAgent,
+        k: int = 3,
+        rng: np.random.Generator | None = None,
+        delay: float = 0.0,
+        log_fn: Callable[[str], None] = print,
+        max_steps: int = 60,
+    ) -> None:
+        """Render ``k`` random episodes step by step (subject requirement).
+
+        Args:
+            agent: Trained agent, played greedily.
+            k: Number of episodes to display.
+            rng: Source of the random episode seeds (default: fresh rng).
+            delay: Optional pause between steps, in seconds.
+            log_fn: Sink for the rendered text (injectable for tests).
+            max_steps: Display safety cap per episode.
+        """
+        rng = rng or np.random.default_rng()
+        for episode in range(k):
+            seed = int(rng.integers(1_000_000))
+            state, _ = self.env.reset(seed=seed)
+            log_fn(f"\n=== Episode {episode + 1}/{k} (seed {seed}) ===")
+            log_fn(self.env.render())
+            total = 0.0
+            for step in range(1, max_steps + 1):
+                action = agent.select_action(state, greedy=True)
+                state, _, terminated, truncated, info = self.env.step(action)
+                raw = float(info["raw_reward"])
+                total += raw
+                log_fn(
+                    f"step {step}: {ACTION_NAMES[action]} -> reward {raw:+.0f} "
+                    f"(cumulative {total:+.0f})"
+                )
+                log_fn(self.env.render())
+                if delay > 0:
+                    time.sleep(delay)
+                if terminated:
+                    log_fn(f"passenger delivered in {step} steps, return {total:+.0f}")
+                    break
+                if truncated:
+                    log_fn(f"episode truncated after {step} steps, return {total:+.0f}")
+                    break
+            else:
+                log_fn(f"display cap reached ({max_steps} steps), return {total:+.0f}")

--- a/src/evaluation/metrics.py
+++ b/src/evaluation/metrics.py
@@ -1,0 +1,121 @@
+"""Evaluation metrics: aggregate statistics over test episodes."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import numpy as np
+from scipy import stats
+
+
+def mean_ci95(values: list[float]) -> tuple[float, float]:
+    """95% confidence interval of the mean (Student t distribution).
+
+    Args:
+        values: Sample values (n >= 2 for a meaningful interval).
+
+    Returns:
+        (low, high) bounds; degenerate (mean, mean) when n < 2.
+    """
+    n = len(values)
+    mean = float(np.mean(values)) if values else 0.0
+    if n < 2:
+        return (mean, mean)
+    sem = float(np.std(values, ddof=1)) / float(np.sqrt(n))
+    t_crit = float(stats.t.ppf(0.975, df=n - 1))
+    return (mean - t_crit * sem, mean + t_crit * sem)
+
+
+@dataclass
+class EvalResults:
+    """Aggregate metrics of a greedy evaluation over N episodes.
+
+    Rewards are native environment rewards. ``mean_episode_seconds`` is the
+    subject's required "mean time for finishing the game".
+    """
+
+    n_episodes: int
+    mean_reward: float
+    std_reward: float
+    median_reward: float
+    reward_ci95: tuple[float, float]
+    reward_percentiles: dict[str, float]  # p25 / p50 / p75 / p95
+    mean_steps: float
+    std_steps: float
+    median_steps: float
+    success_rate: float
+    mean_illegal_actions: float
+    mean_episode_seconds: float
+    rewards: list[float] = field(repr=False)
+    steps: list[int] = field(repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def summary(self) -> str:
+        """Human-readable multi-line summary (console output)."""
+        low, high = self.reward_ci95
+        return (
+            f"episodes            : {self.n_episodes}\n"
+            f"mean reward         : {self.mean_reward:.2f} ± {self.std_reward:.2f} "
+            f"(95% CI [{low:.2f}, {high:.2f}])\n"
+            f"median reward       : {self.median_reward:.2f}\n"
+            f"mean steps          : {self.mean_steps:.2f} ± {self.std_steps:.2f} "
+            f"(median {self.median_steps:.0f})\n"
+            f"success rate        : {self.success_rate * 100:.1f}%\n"
+            f"illegal actions/ep  : {self.mean_illegal_actions:.2f}\n"
+            f"mean time per game  : {self.mean_episode_seconds * 1000:.2f} ms"
+        )
+
+
+def compute_eval_results(
+    rewards: list[float],
+    steps: list[int],
+    successes: list[bool],
+    illegal_actions: list[int],
+    durations: list[float],
+) -> EvalResults:
+    """Aggregate per-episode evaluation data into EvalResults.
+
+    Args:
+        rewards: Native cumulative reward per episode.
+        steps: Step count per episode.
+        successes: Whether each episode terminated (correct dropoff).
+        illegal_actions: Count of -10 penalties per episode.
+        durations: Wall-clock seconds per episode.
+
+    Returns:
+        Aggregated EvalResults.
+
+    Raises:
+        ValueError: If the input lists are empty or of mismatched lengths.
+    """
+    n = len(rewards)
+    if n == 0:
+        raise ValueError("cannot aggregate an empty evaluation")
+    if not (len(steps) == len(successes) == len(illegal_actions) == len(durations) == n):
+        raise ValueError("mismatched metric list lengths")
+    rewards_arr = np.asarray(rewards, dtype=np.float64)
+    steps_arr = np.asarray(steps, dtype=np.float64)
+    return EvalResults(
+        n_episodes=n,
+        mean_reward=float(rewards_arr.mean()),
+        std_reward=float(rewards_arr.std(ddof=1)) if n > 1 else 0.0,
+        median_reward=float(np.median(rewards_arr)),
+        reward_ci95=mean_ci95(rewards),
+        reward_percentiles={
+            "p25": float(np.percentile(rewards_arr, 25)),
+            "p50": float(np.percentile(rewards_arr, 50)),
+            "p75": float(np.percentile(rewards_arr, 75)),
+            "p95": float(np.percentile(rewards_arr, 95)),
+        },
+        mean_steps=float(steps_arr.mean()),
+        std_steps=float(steps_arr.std(ddof=1)) if n > 1 else 0.0,
+        median_steps=float(np.median(steps_arr)),
+        success_rate=float(np.mean([1.0 if s else 0.0 for s in successes])),
+        mean_illegal_actions=float(np.mean(illegal_actions)),
+        mean_episode_seconds=float(np.mean(durations)),
+        rewards=list(rewards),
+        steps=list(steps),
+    )

--- a/src/training/callbacks.py
+++ b/src/training/callbacks.py
@@ -1,0 +1,112 @@
+"""Observer-pattern callbacks for the training loop."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.agents.base_agent import BaseAgent
+    from src.training.trainer import EpisodeResult, TrainingHistory
+
+
+class StopTraining(Exception):  # noqa: N818 — control-flow signal like StopIteration, not an error
+    """Raised by a callback to stop training gracefully."""
+
+
+class Callback:
+    """Base callback: override any hook; defaults are no-ops."""
+
+    def on_training_start(self, n_episodes: int) -> None:
+        """Called once before the first episode."""
+
+    def on_episode_end(self, episode: int, result: EpisodeResult) -> None:
+        """Called after every episode; may raise StopTraining."""
+
+    def on_training_end(self, history: TrainingHistory) -> None:
+        """Called once after the last episode (including early stops)."""
+
+
+class LoggingCallback(Callback):
+    """Prints a rolling summary every ``every`` episodes."""
+
+    def __init__(
+        self, every: int = 1000, window: int = 100, log_fn: Callable[[str], None] = print
+    ) -> None:
+        self.every = every
+        self.window = window
+        self.log_fn = log_fn
+        self._recent_rewards: list[float] = []
+        self._recent_steps: list[int] = []
+
+    def on_episode_end(self, episode: int, result: EpisodeResult) -> None:
+        self._recent_rewards.append(result.raw_reward)
+        self._recent_steps.append(result.steps)
+        if len(self._recent_rewards) > self.window:
+            self._recent_rewards.pop(0)
+            self._recent_steps.pop(0)
+        if (episode + 1) % self.every == 0:
+            mean_r = sum(self._recent_rewards) / len(self._recent_rewards)
+            mean_s = sum(self._recent_steps) / len(self._recent_steps)
+            self.log_fn(
+                f"episode {episode + 1}: reward(last {len(self._recent_rewards)})="
+                f"{mean_r:.2f}, steps={mean_s:.1f}"
+            )
+
+
+class EarlyStoppingCallback(Callback):
+    """Stops when the rolling mean native reward reaches a target.
+
+    Opt-in only: keep disabled during benchmark comparisons (stopping some
+    algorithms earlier than others biases every convergence metric).
+    """
+
+    def __init__(self, target_reward: float = 8.0, window: int = 100) -> None:
+        self.target_reward = target_reward
+        self.window = window
+        self._recent: list[float] = []
+
+    def on_episode_end(self, episode: int, result: EpisodeResult) -> None:
+        self._recent.append(result.raw_reward)
+        if len(self._recent) > self.window:
+            self._recent.pop(0)
+        if (
+            len(self._recent) == self.window
+            and sum(self._recent) / self.window >= self.target_reward
+        ):
+            raise StopTraining(
+                f"early stop at episode {episode + 1}: rolling mean reward "
+                f"{sum(self._recent) / self.window:.2f} >= {self.target_reward}"
+            )
+
+
+class CheckpointCallback(Callback):
+    """Saves the agent every ``every`` episodes."""
+
+    def __init__(self, agent: BaseAgent, path: str | Path, every: int = 5000) -> None:
+        self.agent = agent
+        self.path = Path(path)
+        self.every = every
+
+    def on_episode_end(self, episode: int, result: EpisodeResult) -> None:
+        if (episode + 1) % self.every == 0:
+            self.agent.save(self.path)
+
+
+class TimeBudgetCallback(Callback):
+    """Stops training when a wall-clock deadline is reached.
+
+    The ``clock`` is injectable so tests can use a fake clock instead of
+    sleeping. Episode-level granularity is sufficient: tabular Taxi episodes
+    run sub-millisecond.
+    """
+
+    def __init__(self, deadline: float, clock: Callable[[], float] = time.monotonic) -> None:
+        self.deadline = deadline
+        self.clock = clock
+
+    def on_episode_end(self, episode: int, result: EpisodeResult) -> None:
+        if self.clock() >= self.deadline:
+            raise StopTraining(f"time budget reached at episode {episode + 1}")

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -1,0 +1,180 @@
+"""Generic episodic training loop (Template Method pattern)."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from src.training.callbacks import Callback, StopTraining
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from src.agents.base_agent import BaseAgent
+    from src.config import Config
+    from src.environments.taxi_wrapper import TaxiEnvWrapper
+
+
+@dataclass
+class EpisodeResult:
+    """Outcome of one training episode."""
+
+    reward: float  # possibly shaped (what the agent optimised)
+    raw_reward: float  # native environment reward (what we report)
+    steps: int
+    terminated: bool
+    truncated: bool
+    illegal_actions: int
+
+
+@dataclass
+class TrainingHistory:
+    """Per-episode training metrics plus periodic greedy-probe measurements.
+
+    ``rewards`` are native env rewards; ``shaped_rewards`` differ only when
+    reward shaping is active. Probe entries exist when ``eval_interval > 0``.
+    """
+
+    rewards: list[float] = field(default_factory=list)
+    shaped_rewards: list[float] = field(default_factory=list)
+    steps: list[int] = field(default_factory=list)
+    epsilons: list[float] = field(default_factory=list)
+    illegal_actions: list[int] = field(default_factory=list)
+    terminated: list[bool] = field(default_factory=list)
+    probe_episodes: list[int] = field(default_factory=list)
+    probe_rewards: list[float] = field(default_factory=list)
+    probe_steps: list[float] = field(default_factory=list)
+    wall_time: float = 0.0
+    stop_reason: str = "completed"
+
+    def mean_reward(self, last_n: int = 100) -> float:
+        """Mean native reward over the last ``last_n`` episodes."""
+        if not self.rewards:
+            return 0.0
+        window = self.rewards[-last_n:]
+        return sum(window) / len(window)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Per-episode metrics as a DataFrame (probes excluded)."""
+        import pandas as pd
+
+        return pd.DataFrame(
+            {
+                "episode": range(len(self.rewards)),
+                "reward": self.rewards,
+                "shaped_reward": self.shaped_rewards,
+                "steps": self.steps,
+                "epsilon": self.epsilons,
+                "illegal_actions": self.illegal_actions,
+                "terminated": self.terminated,
+            }
+        )
+
+
+class Trainer:
+    """Runs the episodic RL loop for any BaseAgent on any wrapped env.
+
+    Contract highlights:
+
+    - ``agent.learn`` receives ``terminated`` only — truncation bootstraps.
+    - ``agent.end_episode()`` runs after every episode (schedules, buffers).
+    - Native rewards are read from ``info["raw_reward"]`` so shaping never
+      leaks into reported metrics.
+    - When ``config.eval_interval > 0``, a greedy probe evaluation runs on
+      ``probe_env`` (a separate env instance with dedicated seeds) every
+      ``eval_interval`` episodes, measuring true policy quality independently
+      of the exploration schedule.
+    """
+
+    def __init__(
+        self,
+        agent: BaseAgent,
+        env: TaxiEnvWrapper,
+        config: Config,
+        callbacks: list[Callback] | None = None,
+        probe_env: TaxiEnvWrapper | None = None,
+    ) -> None:
+        self.agent = agent
+        self.env = env
+        self.config = config
+        self.callbacks = callbacks or []
+        self.probe_env = probe_env
+
+    def train(self, n_episodes: int) -> TrainingHistory:
+        """Train for at most ``n_episodes`` episodes.
+
+        Returns:
+            The full TrainingHistory; ``stop_reason`` records early stops.
+        """
+        history = TrainingHistory()
+        start = time.perf_counter()
+        for callback in self.callbacks:
+            callback.on_training_start(n_episodes)
+        try:
+            for episode in range(n_episodes):
+                result = self._run_episode()
+                history.rewards.append(result.raw_reward)
+                history.shaped_rewards.append(result.reward)
+                history.steps.append(result.steps)
+                history.epsilons.append(self.agent.exploration_level)
+                history.illegal_actions.append(result.illegal_actions)
+                history.terminated.append(result.terminated)
+                if (
+                    self.config.eval_interval > 0
+                    and self.probe_env is not None
+                    and (episode + 1) % self.config.eval_interval == 0
+                ):
+                    self._run_probe(episode, history)
+                for callback in self.callbacks:
+                    callback.on_episode_end(episode, result)
+        except StopTraining as stop:
+            history.stop_reason = str(stop)
+        history.wall_time = time.perf_counter() - start
+        for callback in self.callbacks:
+            callback.on_training_end(history)
+        return history
+
+    def _run_episode(self) -> EpisodeResult:
+        state, _ = self.env.reset()
+        total_reward = 0.0
+        total_raw = 0.0
+        illegal = 0
+        steps = 0
+        terminated = truncated = False
+        while not (terminated or truncated):
+            action = self.agent.select_action(state)
+            next_state, reward, terminated, truncated, info = self.env.step(action)
+            raw_reward = float(info["raw_reward"])
+            self.agent.learn(state, action, reward, next_state, terminated)
+            state = next_state
+            total_reward += reward
+            total_raw += raw_reward
+            illegal += raw_reward == -10.0
+            steps += 1
+        self.agent.end_episode()
+        return EpisodeResult(
+            reward=total_reward,
+            raw_reward=total_raw,
+            steps=steps,
+            terminated=terminated,
+            truncated=truncated,
+            illegal_actions=illegal,
+        )
+
+    def _run_probe(self, episode: int, history: TrainingHistory) -> None:
+        from src.evaluation.evaluator import Evaluator
+        from src.utils.seeding import probe_seeds
+
+        assert self.probe_env is not None
+        evaluator = Evaluator(
+            self.probe_env,
+            seeds=probe_seeds(self.config.seed, self.config.n_probe_episodes),
+        )
+        results = evaluator.evaluate(self.agent, self.config.n_probe_episodes)
+        history.probe_episodes.append(episode + 1)
+        history.probe_rewards.append(results.mean_reward)
+        history.probe_steps.append(results.mean_steps)

--- a/tests/evaluation/test_evaluator_metrics.py
+++ b/tests/evaluation/test_evaluator_metrics.py
@@ -1,0 +1,91 @@
+"""Evaluator and metrics tests: fixed-seed determinism, aggregates, display."""
+
+import numpy as np
+import pytest
+
+from src.agents import create_agent
+from src.agents.exploration import UCB
+from src.config import Config
+from src.environments import create_env
+from src.evaluation.evaluator import Evaluator
+from src.evaluation.metrics import compute_eval_results, mean_ci95
+from src.training.trainer import Trainer
+from src.utils.seeding import eval_seeds
+
+
+class TestMetrics:
+    def test_hand_computed_aggregates(self) -> None:
+        results = compute_eval_results(
+            rewards=[10.0, 20.0, 30.0, 40.0],
+            steps=[5, 10, 15, 20],
+            successes=[True, True, False, True],
+            illegal_actions=[0, 1, 2, 1],
+            durations=[0.1, 0.1, 0.1, 0.1],
+        )
+        assert results.mean_reward == 25.0
+        assert results.median_reward == 25.0
+        assert results.mean_steps == 12.5
+        assert results.success_rate == 0.75
+        assert results.mean_illegal_actions == 1.0
+        assert results.mean_episode_seconds == pytest.approx(0.1)
+        assert results.reward_percentiles["p50"] == 25.0
+        low, high = results.reward_ci95
+        assert low < 25.0 < high
+
+    def test_ci95_widens_with_variance(self) -> None:
+        tight = mean_ci95([10.0, 10.1, 9.9, 10.0])
+        wide = mean_ci95([5.0, 15.0, 0.0, 20.0])
+        assert (wide[1] - wide[0]) > (tight[1] - tight[0])
+
+    def test_ci95_degenerate_cases(self) -> None:
+        assert mean_ci95([]) == (0.0, 0.0)
+        assert mean_ci95([7.0]) == (7.0, 7.0)
+
+    def test_empty_and_mismatched_inputs_raise(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            compute_eval_results([], [], [], [], [])
+        with pytest.raises(ValueError, match="mismatched"):
+            compute_eval_results([1.0], [1, 2], [True], [0], [0.1])
+
+    def test_summary_contains_required_outputs(self) -> None:
+        results = compute_eval_results([8.0], [13], [True], [0], [0.001])
+        text = results.summary()
+        assert "mean reward" in text
+        assert "mean time per game" in text  # subject-required output
+
+
+class TestEvaluator:
+    def test_fixed_seeds_give_identical_results(self) -> None:
+        config = Config(algorithm="q_learning", seed=5)
+        env = create_env(config)
+        agent = create_agent(config, env)
+        Trainer(agent, env, config).train(300)
+        evaluator = Evaluator(env, seeds=eval_seeds(config.seed, 20))
+        first = evaluator.evaluate(agent, 20)
+        second = evaluator.evaluate(agent, 20)
+        assert first.rewards == second.rewards
+        assert first.steps == second.steps
+
+    def test_greedy_evaluation_does_not_touch_ucb_counts(self) -> None:
+        config = Config(algorithm="q_learning", exploration="ucb", seed=2)
+        env = create_env(config)
+        agent = create_agent(config, env)
+        strategy = agent.strategy  # type: ignore[attr-defined]
+        assert isinstance(strategy, UCB)
+        counts_before = strategy.counts.sum()
+        Evaluator(env, seeds=eval_seeds(2, 5)).evaluate(agent, 5)
+        assert strategy.counts.sum() == counts_before
+
+    def test_display_episodes_renders_actions_and_grid(self) -> None:
+        config = Config(algorithm="brute_force", seed=9)
+        env = create_env(config)
+        agent = create_agent(config, env)
+        lines: list[str] = []
+        Evaluator(env).display_episodes(
+            agent, k=2, rng=np.random.default_rng(0), log_fn=lines.append, max_steps=5
+        )
+        text = "\n".join(lines)
+        assert text.count("=== Episode") == 2
+        assert "+---------+" in text  # taxi grid rendering
+        assert any(name in text for name in ("South", "North", "East", "West"))
+        assert "cumulative" in text

--- a/tests/training/test_trainer_callbacks.py
+++ b/tests/training/test_trainer_callbacks.py
@@ -1,0 +1,134 @@
+"""Trainer + callbacks tests: end-to-end loop, probes, stop conditions."""
+
+import numpy as np
+import pytest
+
+from src.agents import create_agent
+from src.config import Config
+from src.environments import create_env
+from src.training.callbacks import (
+    CheckpointCallback,
+    EarlyStoppingCallback,
+    LoggingCallback,
+    StopTraining,
+    TimeBudgetCallback,
+)
+from src.training.trainer import EpisodeResult, Trainer, TrainingHistory
+
+
+def make_result(reward: float = 5.0, steps: int = 10) -> EpisodeResult:
+    return EpisodeResult(
+        reward=reward,
+        raw_reward=reward,
+        steps=steps,
+        terminated=True,
+        truncated=False,
+        illegal_actions=0,
+    )
+
+
+class TestTrainerLoop:
+    def test_brute_force_end_to_end(self) -> None:
+        config = Config(algorithm="brute_force", seed=42)
+        env = create_env(config)
+        agent = create_agent(config, env)
+        history = Trainer(agent, env, config).train(5)
+        assert len(history.rewards) == 5
+        assert len(history.steps) == 5
+        assert len(history.terminated) == 5
+        assert history.wall_time > 0
+        assert history.stop_reason == "completed"
+        assert all(s > 0 for s in history.steps)
+
+    def test_q_learning_improves_reward(self) -> None:
+        config = Config(algorithm="q_learning", alpha=0.3, epsilon_decay=0.995, seed=1)
+        env = create_env(config)
+        agent = create_agent(config, env)
+        history = Trainer(agent, env, config).train(800)
+        assert history.mean_reward(100) > np.mean(history.rewards[:100])
+
+    def test_probe_wiring(self) -> None:
+        config = Config(algorithm="q_learning", eval_interval=5, n_probe_episodes=3, seed=3)
+        env = create_env(config)
+        probe_env = create_env(config)
+        agent = create_agent(config, env)
+        history = Trainer(agent, env, config, probe_env=probe_env).train(12)
+        assert history.probe_episodes == [5, 10]
+        assert len(history.probe_rewards) == 2
+        assert len(history.probe_steps) == 2
+
+    def test_history_dataframe_and_dict(self) -> None:
+        history = TrainingHistory(
+            rewards=[1.0, 2.0],
+            shaped_rewards=[1.0, 2.0],
+            steps=[3, 4],
+            epsilons=[0.9, 0.8],
+            illegal_actions=[0, 1],
+            terminated=[True, False],
+        )
+        df = history.to_dataframe()
+        assert list(df.columns) == [
+            "episode",
+            "reward",
+            "shaped_reward",
+            "steps",
+            "epsilon",
+            "illegal_actions",
+            "terminated",
+        ]
+        assert history.to_dict()["rewards"] == [1.0, 2.0]
+        assert history.mean_reward(1) == 2.0
+
+
+class TestCallbacks:
+    def test_time_budget_with_fake_clock(self) -> None:
+        ticks = iter([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+        callback = TimeBudgetCallback(deadline=2.5, clock=lambda: next(ticks))
+        callback.on_episode_end(0, make_result())  # t=0.0
+        callback.on_episode_end(1, make_result())  # t=1.0
+        callback.on_episode_end(2, make_result())  # t=2.0
+        with pytest.raises(StopTraining, match="time budget"):
+            callback.on_episode_end(3, make_result())  # t=3.0
+
+    def test_time_budget_stops_trainer_gracefully(self) -> None:
+        config = Config(algorithm="brute_force", seed=0)
+        env = create_env(config)
+        agent = create_agent(config, env)
+        trainer = Trainer(agent, env, config, callbacks=[TimeBudgetCallback(deadline=0.0)])
+        history = trainer.train(100)
+        assert len(history.rewards) == 1  # stopped after the first episode
+        assert "time budget" in history.stop_reason
+
+    def test_early_stopping_fires_on_window_mean(self) -> None:
+        callback = EarlyStoppingCallback(target_reward=4.0, window=3)
+        callback.on_episode_end(0, make_result(3.0))
+        callback.on_episode_end(1, make_result(4.0))
+        with pytest.raises(StopTraining, match="early stop"):
+            callback.on_episode_end(2, make_result(5.0))
+
+    def test_early_stopping_needs_full_window(self) -> None:
+        callback = EarlyStoppingCallback(target_reward=1.0, window=5)
+        for episode in range(4):
+            callback.on_episode_end(episode, make_result(10.0))  # no raise yet
+
+    def test_checkpoint_writes_file(self, tmp_path: object) -> None:
+        import pathlib
+
+        assert isinstance(tmp_path, pathlib.Path)
+        config = Config(algorithm="q_learning")
+        env = create_env(config)
+        agent = create_agent(config, env)
+        path = tmp_path / "ckpt.npz"
+        callback = CheckpointCallback(agent, path, every=2)
+        callback.on_episode_end(0, make_result())
+        assert not path.exists()
+        callback.on_episode_end(1, make_result())
+        assert path.exists()
+
+    def test_logging_callback_emits(self) -> None:
+        lines: list[str] = []
+        callback = LoggingCallback(every=2, window=10, log_fn=lines.append)
+        callback.on_episode_end(0, make_result(1.0, steps=7))
+        callback.on_episode_end(1, make_result(3.0, steps=9))
+        assert len(lines) == 1
+        assert "reward" in lines[0] and "episode 2" in lines[0]


### PR DESCRIPTION
## Description
Implements BACKLOG Wave 3-4 pipeline tickets (T-4.1.1/2/3, T-4.2.1/2/3):

- **Trainer** (Template Method): `learn()` receives **terminated only, never truncated** — time-limit cuts still bootstrap (classic correctness bug prevented by contract); `end_episode()` after every episode; native rewards read from `info["raw_reward"]` so shaping never leaks into metrics; optional greedy **probe evaluations** on a dedicated probe env every `eval_interval` episodes (true policy quality, decoupled from the exploration schedule)
- **Callbacks** (Observer): Logging, EarlyStopping (opt-in — disabled by default to avoid benchmark bias), Checkpoint, **TimeBudget with injectable clock** (unit-tested with a fake clock, no sleeps), StopTraining control-flow signal
- **Evaluator**: strict greedy policy, **per-episode explicit seeding** → every agent evaluated on identical episodes; `display_episodes()` renders K random episodes step by step (subject requirement)
- **metrics**: EvalResults with mean/std/median, 95% CI (Student t), percentiles, success rate, illegal actions, **mean time per game** (subject-required output)

## Tests effectués
13 nouveaux tests : boucle bout-en-bout (BruteForce), amélioration Q-Learning en 800 épisodes, câblage des sondes, budget temps avec horloge factice, early-stopping sur fenêtre, checkpoint, déterminisme de l'évaluation à seeds fixes, comptes UCB intacts en éval greedy, agrégats calculés à la main. Local : ruff ✅ black ✅ mypy strict ✅ pytest 130/130 ✅.

## Issues liées
Closes #13 (T-4.1.1), Closes #14 (T-4.1.2), Closes #36 (T-4.1.3), Closes #15 (T-4.2.1), Closes #16 (T-4.2.2), Closes #37 (T-4.2.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)