### PR TITLE
feat(dqn): Double-DQN agent with replay buffer and device auto-detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
   `decode_state()`, hook de reward shaping avec `info["raw_reward"]`, seeding premier-reset,
   graine explicite par épisode pour l'évaluation) + factory `create_env()`
 
+- Agent DQN (extension deep RL) : QNetwork (MLP one-hot 2×couches cachées),
+  ReplayBuffer en anneau numpy préalloué, cibles Double-DQN par défaut, mise à jour
+  douce du réseau cible (Polyak), Huber + clipping de gradient, détection
+  automatique du device (CUDA), sauvegarde .pt avec optimiseur et métadonnées
+
 ### Changed
 
 - `.gitignore` : les modèles finaux (`models/final/`) et les résultats agrégés/figures

--- a/src/agents/dqn/dqn_agent.py
+++ b/src/agents/dqn/dqn_agent.py
@@ -1,0 +1,212 @@
+"""Deep Q-Network agent (Mnih et al., 2015) with optional Double DQN targets.
+
+Design choices for the tiny discrete Taxi state space:
+
+- one-hot state encoding into a small MLP (see ``QNetwork``);
+- soft target updates (Polyak averaging, ``tau``) every training step instead
+  of periodic hard copies;
+- Huber loss + gradient-norm clipping for robustness to the -10 penalty
+  outliers;
+- the exploration strategy is shared with the tabular agents: it only ever
+  sees a numpy row of Q-values, so ε-greedy, Boltzmann and UCB all work
+  unchanged on top of the network.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import torch
+import torch.nn.functional as F  # noqa: N812 — torch's canonical alias
+from torch import Tensor, nn
+
+from src.agents.base_agent import BaseAgent
+from src.agents.dqn.q_network import QNetwork
+from src.agents.dqn.replay_buffer import ReplayBuffer
+from src.agents.exploration import create_exploration
+from src.config import Config
+
+FloatArray = npt.NDArray[np.float64]
+
+
+class DQNAgent(BaseAgent):
+    """DQN with experience replay, target network and optional Double DQN.
+
+    Standard target: ``r + γ · max_a' Q_target(s', a') · (1 − terminated)``.
+    Double DQN decouples selection from evaluation to fight maximisation
+    bias: ``r + γ · Q_target(s', argmax_a' Q_policy(s', a')) · (1 − term.)``.
+    """
+
+    name = "dqn"
+
+    def __init__(
+        self,
+        n_states: int,
+        n_actions: int,
+        config: Config,
+        rng: np.random.Generator,
+        n_episodes: int | None = None,
+    ) -> None:
+        """Build networks, optimizer, replay buffer and exploration strategy.
+
+        Args:
+            n_states: Environment state count (one-hot input width).
+            n_actions: Environment action count (network output width).
+            config: Project configuration (DQN block + exploration block).
+            rng: Numpy generator for exploration and replay sampling.
+            n_episodes: Training horizon used to resolve ``config.decay_frac``.
+        """
+        super().__init__(n_states, n_actions, config, rng)
+        torch.manual_seed(config.seed)
+        if config.device == "auto":
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        else:
+            self.device = torch.device(config.device)
+        if self.device.type == "cuda":
+            torch.cuda.manual_seed_all(config.seed)
+
+        self.policy_net = QNetwork(n_states, n_actions, config.hidden_size).to(self.device)
+        self.target_net = QNetwork(n_states, n_actions, config.hidden_size).to(self.device)
+        self.target_net.load_state_dict(self.policy_net.state_dict())
+        self.target_net.eval()
+        self.optimizer = torch.optim.Adam(self.policy_net.parameters(), lr=config.lr)
+        self.loss_fn = nn.SmoothL1Loss()
+        self.buffer = ReplayBuffer(config.buffer_capacity, rng)
+        self.strategy = create_exploration(config, n_states, n_actions, rng, n_episodes)
+        self._step = 0  # global environment-step counter
+        self.last_loss: float | None = None
+
+    # ------------------------------------------------------------------ actions
+
+    def q_values(self, state: int) -> FloatArray:
+        """Row of Q-values predicted by the policy network for ``state``."""
+        with torch.no_grad():
+            q = self.policy_net(self._one_hot([state])).squeeze(0)
+        row: FloatArray = q.cpu().numpy().astype(np.float64)
+        return row
+
+    def select_action(self, state: int, greedy: bool = False) -> int:
+        q_row = self.q_values(state)
+        if greedy:
+            return int(np.argmax(q_row))
+        return self.strategy.select(q_row, state)
+
+    # ------------------------------------------------------------------ learning
+
+    def learn(
+        self, state: int, action: int, reward: float, next_state: int, terminated: bool
+    ) -> None:
+        self.buffer.push(state, action, reward, next_state, terminated)
+        self._step += 1
+        if self._step % self.config.train_every != 0:
+            return
+        if len(self.buffer) < max(self.config.warmup_steps, self.config.batch_size):
+            return
+        self._train_step()
+
+    def _train_step(self) -> None:
+        """One gradient step on a replayed minibatch, then a soft target update."""
+        states, actions, rewards, next_states, terminated = self.buffer.sample(
+            self.config.batch_size
+        )
+        state_batch = self._one_hot(states)
+        next_batch = self._one_hot(next_states)
+        action_batch = torch.as_tensor(actions, dtype=torch.int64, device=self.device)
+        reward_batch = torch.as_tensor(rewards, dtype=torch.float32, device=self.device)
+        # (1 − terminated): truncated transitions keep bootstrapping.
+        bootstrap_mask = torch.as_tensor(~terminated, dtype=torch.float32, device=self.device)
+
+        q_pred = self.policy_net(state_batch).gather(1, action_batch.unsqueeze(1)).squeeze(1)
+        with torch.no_grad():
+            if self.config.double_dqn:
+                best_next = self.policy_net(next_batch).argmax(dim=1, keepdim=True)
+                next_q = self.target_net(next_batch).gather(1, best_next).squeeze(1)
+            else:
+                next_q = self.target_net(next_batch).max(dim=1).values
+            target = reward_batch + self.config.gamma * next_q * bootstrap_mask
+
+        loss = self.loss_fn(q_pred, target)
+        self.optimizer.zero_grad()
+        loss.backward()
+        nn.utils.clip_grad_norm_(self.policy_net.parameters(), self.config.grad_clip)
+        self.optimizer.step()
+        self._soft_update()
+        self.last_loss = float(loss.item())
+
+    def _soft_update(self) -> None:
+        """Polyak averaging: ``target ← tau · policy + (1 − tau) · target``."""
+        tau = self.config.tau
+        with torch.no_grad():
+            for target_param, param in zip(
+                self.target_net.parameters(), self.policy_net.parameters(), strict=True
+            ):
+                target_param.mul_(1.0 - tau).add_(param, alpha=tau)
+
+    def end_episode(self) -> None:
+        super().end_episode()
+        self.strategy.decay()
+
+    # ------------------------------------------------------------------ persistence
+
+    def save(self, path: str | Path) -> None:
+        """Persist networks, optimizer and metadata as a ``.pt`` checkpoint."""
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        metadata = {
+            "algorithm": self.name,
+            "n_states": self.n_states,
+            "n_actions": self.n_actions,
+            "n_episodes_trained": self.n_episodes_trained,
+            "config_hash": self.config.config_hash(),
+            "config": self.config.to_dict(),
+            "saved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        }
+        torch.save(
+            {
+                "policy_state_dict": self.policy_net.state_dict(),
+                "target_state_dict": self.target_net.state_dict(),
+                "optimizer_state_dict": self.optimizer.state_dict(),
+                "step": self._step,
+                "metadata": metadata,
+            },
+            path,
+        )
+
+    def load(self, path: str | Path) -> None:
+        """Restore networks, optimizer and counters from a ``.pt`` checkpoint."""
+        checkpoint: dict[str, Any] = torch.load(
+            Path(path), map_location=self.device, weights_only=False
+        )
+        metadata = checkpoint["metadata"]
+        saved_shape = (int(metadata["n_states"]), int(metadata["n_actions"]))
+        if saved_shape != (self.n_states, self.n_actions):
+            raise ValueError(
+                f"Model dimensions {saved_shape} do not match environment "
+                f"({self.n_states}, {self.n_actions})"
+            )
+        self.policy_net.load_state_dict(checkpoint["policy_state_dict"])
+        self.target_net.load_state_dict(checkpoint["target_state_dict"])
+        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self._step = int(checkpoint["step"])
+        self.n_episodes_trained = int(metadata.get("n_episodes_trained", 0))
+
+    def memory_bytes(self) -> int:
+        n_params = sum(p.numel() for p in self.policy_net.parameters()) + sum(
+            p.numel() for p in self.target_net.parameters()
+        )
+        return n_params * 4 + self.buffer.nbytes()
+
+    @property
+    def exploration_level(self) -> float:
+        return self.strategy.epsilon_like
+
+    # ------------------------------------------------------------------ helpers
+
+    def _one_hot(self, states: npt.NDArray[np.int64] | list[int]) -> Tensor:
+        """One-hot encode a batch of state indices on the agent's device."""
+        indices = torch.as_tensor(np.asarray(states), dtype=torch.int64, device=self.device)
+        return F.one_hot(indices, num_classes=self.n_states).float()

--- a/src/agents/dqn/q_network.py
+++ b/src/agents/dqn/q_network.py
@@ -1,0 +1,44 @@
+"""Fully-connected Q-network mapping one-hot encoded states to action values."""
+
+from __future__ import annotations
+
+from torch import Tensor, nn
+
+
+class QNetwork(nn.Module):
+    """MLP approximating ``Q(s, ·)`` from a one-hot state encoding.
+
+    Architecture: ``Linear(n_states, hidden) → ReLU → Linear(hidden, hidden)
+    → ReLU → Linear(hidden, n_actions)``. Discrete Taxi states carry no
+    metric structure, so the one-hot input keeps the network from inventing
+    spurious distances between state indices.
+    """
+
+    def __init__(self, n_states: int, n_actions: int, hidden_size: int = 128) -> None:
+        """Build the network.
+
+        Args:
+            n_states: Input width (one-hot state dimension).
+            n_actions: Output width (one Q-value per action).
+            hidden_size: Width of the two hidden layers.
+        """
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(n_states, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, n_actions),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Compute Q-values for a batch of one-hot states.
+
+        Args:
+            x: Float tensor of shape ``(batch, n_states)``.
+
+        Returns:
+            Float tensor of shape ``(batch, n_actions)``.
+        """
+        out: Tensor = self.net(x)
+        return out

--- a/src/agents/dqn/replay_buffer.py
+++ b/src/agents/dqn/replay_buffer.py
@@ -1,0 +1,99 @@
+"""Ring-buffer experience replay backed by preallocated numpy arrays.
+
+A structure-of-arrays layout (one preallocated array per field) beats a deque
+of transition tuples on both memory (no per-tuple Python object overhead) and
+sampling speed (one fancy-index gather per field instead of unpacking
+``batch_size`` tuples).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+Batch = tuple[
+    npt.NDArray[np.int64],
+    npt.NDArray[np.int64],
+    npt.NDArray[np.float32],
+    npt.NDArray[np.int64],
+    npt.NDArray[np.bool_],
+]
+
+
+class ReplayBuffer:
+    """Fixed-capacity FIFO transition store with uniform random sampling.
+
+    Once full, the oldest transition is overwritten first (ring semantics).
+    Sampling is uniform with replacement over the filled region only.
+    """
+
+    def __init__(self, capacity: int, rng: np.random.Generator) -> None:
+        """Preallocate storage.
+
+        Args:
+            capacity: Maximum number of transitions retained.
+            rng: Random generator used for sampling (owned by the agent).
+        """
+        self.capacity = capacity
+        self.rng = rng
+        self._states: npt.NDArray[np.int64] = np.zeros(capacity, dtype=np.int64)
+        self._actions: npt.NDArray[np.int64] = np.zeros(capacity, dtype=np.int64)
+        self._rewards: npt.NDArray[np.float32] = np.zeros(capacity, dtype=np.float32)
+        self._next_states: npt.NDArray[np.int64] = np.zeros(capacity, dtype=np.int64)
+        self._terminated: npt.NDArray[np.bool_] = np.zeros(capacity, dtype=np.bool_)
+        self._pos = 0
+        self._size = 0
+
+    def push(
+        self, state: int, action: int, reward: float, next_state: int, terminated: bool
+    ) -> None:
+        """Store one transition, overwriting the oldest one when full.
+
+        Args:
+            state: State before the action.
+            action: Action taken.
+            reward: Reward received (possibly shaped).
+            next_state: Successor state.
+            terminated: True only for true MDP termination (never truncation).
+        """
+        i = self._pos
+        self._states[i] = state
+        self._actions[i] = action
+        self._rewards[i] = reward
+        self._next_states[i] = next_state
+        self._terminated[i] = terminated
+        self._pos = (self._pos + 1) % self.capacity
+        self._size = min(self._size + 1, self.capacity)
+
+    def sample(self, batch_size: int) -> Batch:
+        """Sample ``batch_size`` transitions uniformly from the filled region.
+
+        Args:
+            batch_size: Number of transitions to draw (with replacement).
+
+        Returns:
+            Tuple ``(states, actions, rewards, next_states, terminated)`` of
+            numpy arrays, each of length ``batch_size``.
+        """
+        indices = self.rng.integers(self._size, size=batch_size)
+        return (
+            self._states[indices],
+            self._actions[indices],
+            self._rewards[indices],
+            self._next_states[indices],
+            self._terminated[indices],
+        )
+
+    def __len__(self) -> int:
+        """Number of transitions currently stored."""
+        return self._size
+
+    def nbytes(self) -> int:
+        """Total size of the preallocated storage arrays, in bytes."""
+        return int(
+            self._states.nbytes
+            + self._actions.nbytes
+            + self._rewards.nbytes
+            + self._next_states.nbytes
+            + self._terminated.nbytes
+        )

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -172,11 +172,13 @@ def cmd_train(args: argparse.Namespace) -> int:
         f"({history.stop_reason})"
     )
 
+    # Torch checkpoints for DQN, compressed numpy archives for tabular agents.
+    suffix = ".pt" if config.algorithm == "dqn" else ".npz"
     model_path = Path(
         args.save
         if getattr(args, "save", None)
         else Path(config.model_path)
-        / f"{config.algorithm}_{datetime.datetime.now():%Y%m%dT%H%M%S}.npz"
+        / f"{config.algorithm}_{datetime.datetime.now():%Y%m%dT%H%M%S}{suffix}"
     )
     agent.save(model_path)
     print(f"model saved to {model_path}")
@@ -199,6 +201,16 @@ def cmd_train(args: argparse.Namespace) -> int:
 
 
 def _load_model_metadata(path: Path) -> dict[str, object]:
+    """Read the metadata dict embedded in a saved model (.npz or .pt)."""
+    if path.suffix == ".pt":
+        # DQN torch checkpoint. Lazy import: the tabular path never pays torch.
+        import torch
+
+        checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+        metadata = checkpoint.get("metadata") if isinstance(checkpoint, dict) else None
+        if not isinstance(metadata, dict):
+            raise ValueError(f"{path} does not contain model metadata")
+        return dict(metadata)
     data = np.load(path, allow_pickle=False)
     if "metadata" not in data:
         raise ValueError(f"{path} does not contain model metadata")

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -82,7 +82,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_config_overrides(train)
 
     evaluate = subparsers.add_parser("eval", help="evaluate a saved model")
-    evaluate.add_argument("--model", required=True, help="path to a saved model (.npz)")
+    evaluate.add_argument("--model", required=True, help="path to a saved model (.npz / .pt)")
     evaluate.add_argument("--test-episodes", dest="n_test_episodes", type=int, default=None)
     evaluate.add_argument("--show-episodes", type=int, default=None)
     evaluate.add_argument("--seed", type=int, default=None)

--- a/tests/agents/test_agents_tabular.py
+++ b/tests/agents/test_agents_tabular.py
@@ -44,9 +44,11 @@ class TestBaseContracts:
         assert isinstance(agent, QLearningAgent)
         assert agent.q_table.shape == (fake_env.n_states, fake_env.n_actions)
 
-    def test_create_agent_dqn_not_yet_available(self, fake_env: object) -> None:
-        with pytest.raises(ImportError):
-            create_agent(Config(algorithm="dqn"), fake_env)
+    def test_create_agent_resolves_dqn_lazily(self, fake_env: object) -> None:
+        from src.agents.dqn.dqn_agent import DQNAgent
+
+        agent = create_agent(Config(algorithm="dqn", device="cpu"), fake_env)
+        assert isinstance(agent, DQNAgent)
 
     @pytest.mark.parametrize("name", sorted(AGENT_REGISTRY))
     def test_select_action_in_range(self, name: str, fake_env: object) -> None:

--- a/tests/agents/test_dqn.py
+++ b/tests/agents/test_dqn.py
@@ -1,0 +1,223 @@
+"""DQN tests: network shape, replay-buffer semantics, agent learning dynamics.
+
+Every test forces ``device="cpu"`` so CI stays deterministic and GPU-free;
+the end-to-end convergence test on the real Taxi-v3 is marked ``slow`` and
+excluded by the default pytest addopts.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from src.agents import create_agent
+from src.agents.dqn.dqn_agent import DQNAgent
+from src.agents.dqn.q_network import QNetwork
+from src.agents.dqn.replay_buffer import ReplayBuffer
+from src.config import Config
+
+N_STATES, N_ACTIONS = 6, 4
+
+
+def tiny_config(**overrides: object) -> Config:
+    """Small, CPU-forced DQN config that trains from the very first steps."""
+    params: dict[str, object] = {
+        "algorithm": "dqn",
+        "device": "cpu",
+        "hidden_size": 16,
+        "warmup_steps": 4,
+        "batch_size": 4,
+        "buffer_capacity": 64,
+        "train_every": 1,
+        "seed": 3,
+    }
+    params.update(overrides)
+    return Config(**params)  # type: ignore[arg-type]
+
+
+def make_agent(config: Config | None = None, seed: int = 7) -> DQNAgent:
+    return DQNAgent(N_STATES, N_ACTIONS, config or tiny_config(), np.random.default_rng(seed))
+
+
+def params_equal(a: torch.nn.Module, b: torch.nn.Module) -> bool:
+    return all(torch.equal(pa, pb) for pa, pb in zip(a.parameters(), b.parameters(), strict=True))
+
+
+class TestQNetwork:
+    def test_output_shape(self) -> None:
+        net = QNetwork(N_STATES, N_ACTIONS, hidden_size=16)
+        states = torch.tensor([0, 1, 2, 3, 4, 5, 0])
+        x = torch.nn.functional.one_hot(states, num_classes=N_STATES).float()
+        assert net(x).shape == (7, N_ACTIONS)
+
+
+class TestReplayBuffer:
+    def test_len_grows_then_caps_at_capacity(self) -> None:
+        buffer = ReplayBuffer(8, np.random.default_rng(0))
+        for i in range(5):
+            buffer.push(i, 0, 0.0, i + 1, False)
+        assert len(buffer) == 5
+        for i in range(10):
+            buffer.push(i, 0, 0.0, i + 1, False)
+        assert len(buffer) == 8
+
+    def test_fifo_overwrite_drops_oldest(self) -> None:
+        buffer = ReplayBuffer(8, np.random.default_rng(0))
+        for i in range(9):  # capacity + 1 distinct rewards
+            buffer.push(i, 0, float(i), i + 1, False)
+        stored = set(buffer._rewards.tolist())
+        assert 0.0 not in stored  # the oldest transition was overwritten
+        assert stored == {float(i) for i in range(1, 9)}
+
+    def test_sample_shapes_and_dtypes(self) -> None:
+        buffer = ReplayBuffer(16, np.random.default_rng(0))
+        for i in range(10):
+            buffer.push(i, i % 4, -1.5, i + 1, i % 2 == 0)
+        states, actions, rewards, next_states, terminated = buffer.sample(4)
+        for array in (states, actions, rewards, next_states, terminated):
+            assert array.shape == (4,)
+        assert states.dtype == np.int64
+        assert actions.dtype == np.int64
+        assert rewards.dtype == np.float32
+        assert next_states.dtype == np.int64
+        assert terminated.dtype == np.bool_
+
+    def test_sample_only_over_filled_region(self) -> None:
+        buffer = ReplayBuffer(64, np.random.default_rng(0))
+        for state in (1, 2, 3):
+            buffer.push(state, 0, 9.0, state, False)
+        for _ in range(20):
+            states, _, rewards, _, _ = buffer.sample(32)
+            assert set(states.tolist()) <= {1, 2, 3}
+            assert set(rewards.tolist()) == {9.0}
+
+
+class TestDQNAgent:
+    def test_learn_updates_policy_net_and_records_loss(self) -> None:
+        agent = make_agent()
+        before = [p.clone() for p in agent.policy_net.parameters()]
+        assert agent.last_loss is None
+        for i in range(10):
+            agent.learn(i % N_STATES, i % N_ACTIONS, -1.0, (i + 1) % N_STATES, False)
+        assert isinstance(agent.last_loss, float)
+        assert any(
+            not torch.equal(b, p)
+            for b, p in zip(before, agent.policy_net.parameters(), strict=True)
+        )
+
+    def test_target_net_soft_updates_toward_policy(self) -> None:
+        agent = make_agent()
+        assert params_equal(agent.policy_net, agent.target_net)  # synced at init
+        target_before = [p.clone() for p in agent.target_net.parameters()]
+        for i in range(10):
+            agent.learn(i % N_STATES, i % N_ACTIONS, -1.0, (i + 1) % N_STATES, False)
+        # The target moved (Polyak averaging ran) ...
+        assert any(
+            not torch.equal(b, p)
+            for b, p in zip(target_before, agent.target_net.parameters(), strict=True)
+        )
+        # ... but lags behind the policy (tau << 1).
+        assert not params_equal(agent.policy_net, agent.target_net)
+
+    def test_double_dqn_flag_changes_updates(self) -> None:
+        agents = {
+            flag: DQNAgent(
+                N_STATES,
+                N_ACTIONS,
+                tiny_config(double_dqn=flag, lr=0.05),
+                np.random.default_rng(0),
+            )
+            for flag in (True, False)
+        }
+        rng = np.random.default_rng(42)
+        transitions = [
+            (
+                int(rng.integers(N_STATES)),
+                int(rng.integers(N_ACTIONS)),
+                float(rng.normal(0.0, 5.0)),
+                int(rng.integers(N_STATES)),
+                False,
+            )
+            for _ in range(40)
+        ]
+        for agent in agents.values():  # identical init, identical transitions
+            for transition in transitions:
+                agent.learn(*transition)
+        assert not params_equal(agents[True].policy_net, agents[False].policy_net)
+
+    def test_terminated_masks_bootstrap(self) -> None:
+        # Q(3, ·) is trained high first; if the terminal mask were broken, the
+        # target for (2, 1) would be 5 + γ·max Q(3) ≈ 24.8 instead of 5.
+        config = tiny_config(lr=0.01, buffer_capacity=512, batch_size=8)
+        agent = make_agent(config, seed=1)
+        for _ in range(150):
+            agent.learn(3, 0, 20.0, 4, True)
+        for _ in range(300):
+            agent.learn(2, 1, 5.0, 3, True)
+        assert agent.q_values(3)[0] > 10.0  # the decoy value is in place
+        assert abs(agent.q_values(2)[1] - 5.0) < 0.5  # targets equal rewards
+
+    def test_greedy_selection_and_exploration_decay(self) -> None:
+        agent = make_agent(tiny_config(epsilon=1.0, epsilon_min=0.0, epsilon_decay=0.5))
+        action = agent.select_action(0, greedy=True)
+        assert action == int(np.argmax(agent.q_values(0)))
+        assert agent.exploration_level == 1.0
+        agent.end_episode()
+        assert agent.exploration_level == 0.5
+        assert agent.n_episodes_trained == 1
+
+    def test_save_load_round_trip(self, tmp_path: Path) -> None:
+        agent = make_agent()
+        for i in range(20):
+            agent.learn(i % N_STATES, i % N_ACTIONS, -1.0, (i + 1) % N_STATES, False)
+        agent.end_episode()
+        path = tmp_path / "dqn.pt"
+        agent.save(path)
+
+        clone = make_agent(seed=99)
+        assert not params_equal(agent.policy_net, clone.policy_net)
+        clone.load(path)
+        assert params_equal(agent.policy_net, clone.policy_net)
+        assert params_equal(agent.target_net, clone.target_net)
+        assert clone.n_episodes_trained == agent.n_episodes_trained
+        assert clone._step == agent._step
+
+    def test_load_dimension_mismatch_raises(self, tmp_path: Path) -> None:
+        agent = make_agent()
+        path = tmp_path / "dqn.pt"
+        agent.save(path)
+        other = DQNAgent(N_STATES + 1, N_ACTIONS, tiny_config(), np.random.default_rng(0))
+        with pytest.raises(ValueError, match="dimensions"):
+            other.load(path)
+
+    def test_memory_bytes_counts_nets_and_buffer(self) -> None:
+        agent = make_agent()
+        n_params = sum(p.numel() for p in agent.policy_net.parameters())
+        assert agent.memory_bytes() == 2 * n_params * 4 + agent.buffer.nbytes()
+
+    def test_create_agent_builds_dqn(self, fake_env: object) -> None:
+        agent = create_agent(Config(algorithm="dqn", device="cpu"), fake_env)
+        assert isinstance(agent, DQNAgent)
+        assert agent.policy_net.net[0].in_features == fake_env.n_states  # type: ignore[union-attr]
+
+
+@pytest.mark.slow
+class TestDQNConvergence:
+    def test_learns_taxi_v3(self) -> None:
+        from src.environments import create_env
+        from src.evaluation.evaluator import Evaluator
+        from src.training.trainer import Trainer
+        from src.utils.seeding import eval_seeds
+
+        config = Config(
+            algorithm="dqn",
+            device="cpu",
+            n_train_episodes=1500,
+            decay_frac=0.5,
+        )
+        env = create_env(config)
+        agent = create_agent(config, env, n_episodes=config.n_train_episodes)
+        Trainer(agent, env, config).train(config.n_train_episodes)
+        results = Evaluator(env, seeds=eval_seeds(config.seed, 30)).evaluate(agent, 30)
+        assert results.mean_reward > 0


### PR DESCRIPTION
## Description
Implements the DQN extension (T-3.3.1..4):

- **QNetwork**: one-hot(n_states) → 2×hidden ReLU MLP (sized from the env, works on the 14,400-state multi-passenger env too)
- **ReplayBuffer**: preallocated numpy ring storage (SoA), FIFO overwrite, uniform sampling
- **DQNAgent**: Adam + Huber + grad-norm clipping, Polyak soft target updates every train step, **Double DQN by default**, `(1 − terminated)` bootstrap mask (truncation still bootstraps — verified by a decoy-state test that catches a broken mask), reuses the shared exploration strategies on the network's Q-row, warm-up before learning, `.pt` save/load with optimizer state and metadata, `memory_bytes()` for the benchmark
- Device resolution `auto` → CUDA when available (RTX 2060 verified); CI tests force CPU for determinism
- CLI: model metadata loading dispatches on suffix (`.pt`/`.npz`); DQN checkpoints named `.pt`

**Verification**: 800 real episodes on CUDA → final-100 training reward **−3.3** vs ~−700 random; the slow-marked 1500-episode convergence test passes (greedy eval > 0); CLI train→eval round-trip reproduces identical greedy results from a reloaded checkpoint.

## Tests effectués
15 nouveaux tests (buffer FIFO/échantillonnage, formes réseau, apprentissage effectif, masque terminated avec état-piège, divergence Double-DQN déterministe, round-trip save/load bit-à-bit) + test lent de convergence. Local : ruff ✅ black ✅ mypy strict ✅ pytest 144/144 ✅.

## Issues liées
Closes #51 (T-3.3.1), Closes #52 (T-3.3.2), Closes #53 (T-3.3.3), Closes #54 (T-3.3.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)