### PR TITLE
feat(env): 2-passenger MultiPassengerTaxiEnv (14,400 states)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
   `decode_state()`, hook de reward shaping avec `info["raw_reward"]`, seeding premier-reset,
   graine explicite par épisode pour l'évaluation) + factory `create_env()`
 
+- Environnement multi-passagers (bonus du sujet) : `MultiPassengerTaxiEnv`
+  à 14 400 états (25×6²×4², corrige le décompte 10 000 de CADRAGE.md qui omettait
+  le statut « livré »), capacité 2, règles pickup/dropoff déterministes
+  (plus petit indice), dépose hors destination interdite, TimeLimit 500 ;
+  analyse d'ordre de route (`route_analysis.py`) ; protocole `EnvWrapper` partagé
+
 ### Changed
 
 - `.gitignore` : les modèles finaux (`models/final/`) et les résultats agrégés/figures

--- a/src/environments/__init__.py
+++ b/src/environments/__init__.py
@@ -2,13 +2,65 @@
 
 from __future__ import annotations
 
+from typing import Any, Protocol
+
 from src.config import Config
+from src.environments.multi_passenger_env import (
+    MULTI_MAX_STEPS,
+    MultiEnvWrapper,
+    MultiPassengerTaxiEnv,
+)
 from src.environments.taxi_wrapper import TAXI_LOCATIONS, RewardFn, TaxiEnvWrapper
 
-__all__ = ["TAXI_LOCATIONS", "RewardFn", "TaxiEnvWrapper", "create_env"]
+__all__ = [
+    "MULTI_MAX_STEPS",
+    "TAXI_LOCATIONS",
+    "EnvWrapper",
+    "MultiEnvWrapper",
+    "MultiPassengerTaxiEnv",
+    "RewardFn",
+    "TaxiEnvWrapper",
+    "create_env",
+]
 
 
-def create_env(config: Config, reward_fn: RewardFn | None = None) -> TaxiEnvWrapper:
+class EnvWrapper(Protocol):
+    """Common surface of the project env wrappers (structural typing).
+
+    Satisfied by :class:`TaxiEnvWrapper` and :class:`MultiEnvWrapper`; this is
+    what the Trainer, Evaluator and agent factory consume: int states/actions,
+    first-reset constructor seeding with explicit ``reset(seed=...)``
+    passthrough, and ``info["raw_reward"]`` set on every step.
+    """
+
+    @property
+    def n_states(self) -> int:
+        """Number of discrete states."""
+        ...
+
+    @property
+    def n_actions(self) -> int:
+        """Number of discrete actions."""
+        ...
+
+    def reset(self, seed: int | None = None) -> tuple[int, dict[str, Any]]:
+        """Reset the environment, honouring the project seeding convention."""
+        ...
+
+    def step(self, action: int) -> tuple[int, float, bool, bool, dict[str, Any]]:
+        """Take one step; ``info["raw_reward"]`` holds the native reward."""
+        ...
+
+    def render(self) -> str:
+        """Return the current ANSI rendering."""
+        ...
+
+    def close(self) -> None:
+        """Release the underlying environment resources."""
+        ...
+
+
+def create_env(config: Config, reward_fn: RewardFn | None = None) -> EnvWrapper:
     """Build the environment described by the configuration.
 
     Args:
@@ -18,10 +70,10 @@ def create_env(config: Config, reward_fn: RewardFn | None = None) -> TaxiEnvWrap
             wrapper (wired by the benchmarking module).
 
     Returns:
-        A ready-to-use environment wrapper.
-
-    Raises:
-        NotImplementedError: If ``config.env`` is ``"multi"`` (upcoming).
+        A ready-to-use environment wrapper. For ``env == "multi"`` the step
+        cap is the fixed ``MULTI_MAX_STEPS`` (500) TimeLimit rather than
+        ``config.max_steps_per_episode``: two-passenger optimal routes are
+        roughly twice Taxi-v3's, plus early-training wandering.
     """
     if config.env == "taxi":
         return TaxiEnvWrapper(
@@ -29,4 +81,4 @@ def create_env(config: Config, reward_fn: RewardFn | None = None) -> TaxiEnvWrap
             seed=config.seed,
             max_steps=config.max_steps_per_episode,
         )
-    raise NotImplementedError("coming in feature/multi-passenger")
+    return MultiEnvWrapper(reward_fn=reward_fn, seed=config.seed, max_steps=MULTI_MAX_STEPS)

--- a/src/environments/multi_passenger_env.py
+++ b/src/environments/multi_passenger_env.py
@@ -1,0 +1,470 @@
+"""Two-passenger extension of Taxi-v3 with route optimisation (bonus extension).
+
+The subject's bonus asks for a taxi that "collects 2 people and obtain 4
+locations for each of them, the goal being to optimize the route". This module
+provides:
+
+- :class:`MultiPassengerTaxiEnv`, a deterministic Gymnasium environment on the
+  exact Taxi-v3 5x5 map with two independent passengers;
+- module-level :func:`encode` / :func:`decode` for the mixed-radix state
+  encoding (14,400 states);
+- :class:`MultiEnvWrapper`, the project-facing wrapper mirroring
+  :class:`~src.environments.taxi_wrapper.TaxiEnvWrapper`'s public surface so
+  the Trainer and Evaluator work unchanged.
+
+State-count note: docs/CADRAGE.md estimated 25 x 5^2 x 4^2 = 10,000 states
+(5 statuses per passenger, as in Taxi-v3). That is incorrect here: delivering
+the first passenger does *not* end the episode, so "delivered" must be a
+distinct status from the four landmarks and "in taxi". Each passenger thus has
+6 statuses and the state space is 25 x 6^2 x 4^2 = **14,400** states.
+"""
+
+from __future__ import annotations
+
+from typing import Any, SupportsInt, cast
+
+import gymnasium as gym
+import numpy as np
+from gymnasium.spaces import Discrete, Space
+from gymnasium.wrappers import TimeLimit
+
+from src.environments.taxi_wrapper import RewardFn
+
+# Same ascii map as Taxi-v3 (gymnasium.envs.toy_text.taxi.MAP). Walls are
+# parsed the same way: the "|" between two columns blocks East/West moves,
+# and the grid borders clamp every move.
+MAP = [
+    "+---------+",
+    "|R: | : :G|",
+    "| : | : : |",
+    "| : : : : |",
+    "| | : | : |",
+    "|Y| : |B: |",
+    "+---------+",
+]
+
+#: Grid coordinates of the four landmarks, in index order R, G, Y, B
+#: (mirrors ``TaxiEnv.locs`` and ``TAXI_LOCATIONS``).
+LOCATIONS: tuple[tuple[int, int], ...] = ((0, 0), (0, 4), (4, 0), (4, 3))
+LOCATION_NAMES: tuple[str, ...] = ("R", "G", "Y", "B")
+
+N_ROWS = 5
+N_COLS = 5
+N_LOCATIONS = 4
+N_PASSENGERS = 2
+
+#: Passenger statuses: 0-3 = waiting at landmark R/G/Y/B, 4 = in taxi,
+#: 5 = delivered (distinct from "in taxi": the episode continues after the
+#: first delivery, unlike single-passenger Taxi-v3).
+STATUS_IN_TAXI = 4
+STATUS_DELIVERED = 5
+N_STATUSES = 6
+
+#: 25 taxi cells x 6^2 passenger statuses x 4^2 destinations = 14,400.
+N_STATES = N_ROWS * N_COLS * N_STATUSES**2 * N_LOCATIONS**2
+N_ACTIONS = 6
+
+#: Episode step cap applied by ``create_env`` via ``TimeLimit`` (500, not
+#: Taxi-v3's 200: optimal two-passenger routes are roughly twice as long and
+#: early training wanders a lot). The env itself has no internal step cap.
+MULTI_MAX_STEPS = 500
+
+MOVE_REWARD = -1.0
+ILLEGAL_REWARD = -10.0
+DELIVER_REWARD = 20.0
+
+
+def encode(
+    taxi_row: int, taxi_col: int, status_0: int, status_1: int, dest_0: int, dest_1: int
+) -> int:
+    """Encode state components into a single integer (mixed radix).
+
+    Most significant first: ``((((row*5 + col)*6 + s0)*6 + s1)*4 + d0)*4 + d1``.
+
+    Args:
+        taxi_row: Taxi row in ``[0, 5)``.
+        taxi_col: Taxi column in ``[0, 5)``.
+        status_0: Passenger 0 status in ``[0, 6)``.
+        status_1: Passenger 1 status in ``[0, 6)``.
+        dest_0: Passenger 0 destination landmark in ``[0, 4)``.
+        dest_1: Passenger 1 destination landmark in ``[0, 4)``.
+
+    Returns:
+        Encoded state in ``[0, 14_400)``.
+    """
+    state = taxi_row * N_COLS + taxi_col
+    state = state * N_STATUSES + status_0
+    state = state * N_STATUSES + status_1
+    state = state * N_LOCATIONS + dest_0
+    state = state * N_LOCATIONS + dest_1
+    return state
+
+
+def decode(state: int) -> tuple[int, int, int, int, int, int]:
+    """Decode an encoded state into its components (inverse of :func:`encode`).
+
+    Args:
+        state: Encoded state in ``[0, 14_400)``.
+
+    Returns:
+        Tuple ``(taxi_row, taxi_col, status_0, status_1, dest_0, dest_1)``.
+    """
+    state, dest_1 = divmod(state, N_LOCATIONS)
+    state, dest_0 = divmod(state, N_LOCATIONS)
+    state, status_1 = divmod(state, N_STATUSES)
+    state, status_0 = divmod(state, N_STATUSES)
+    taxi_row, taxi_col = divmod(state, N_COLS)
+    return taxi_row, taxi_col, status_0, status_1, dest_0, dest_1
+
+
+class MultiPassengerTaxiEnv(gym.Env[int, int]):
+    """Deterministic two-passenger taxi on the Taxi-v3 5x5 map.
+
+    Actions (same order as Taxi-v3): 0 South, 1 North, 2 East, 3 West,
+    4 Pickup, 5 Dropoff. Moves cost -1; walls and borders block the move
+    (position unchanged, still -1). Contextual actions are deterministic with
+    a lowest-index-wins rule when both passengers are eligible:
+
+    - Pickup: a waiting passenger on the taxi cell boards (status -> 4) for
+      -1; with no eligible passenger the action is illegal (-10). Capacity is
+      2: both passengers may ride simultaneously, which is required for
+      genuine route optimisation.
+    - Dropoff: on a landmark that is the destination of an in-taxi passenger,
+      that passenger is delivered (status -> 5) for +20; anything else is
+      illegal (-10). **Deliberate divergence from Taxi-v3**: mid-episode
+      set-down (dropping an in-taxi passenger anywhere other than their
+      destination) is forbidden and penalised -10 — the passenger stays in
+      the taxi — whereas Taxi-v3 re-places the passenger on the landmark for
+      a plain -1.
+
+    The episode terminates when both passengers are delivered. The env has no
+    internal step cap; ``create_env`` wraps it in ``TimeLimit(500)``.
+
+    Initial states sample the taxi cell uniformly over the 25 cells, two
+    *distinct* start landmarks, and per-passenger destinations different from
+    that passenger's start (the two destinations may coincide).
+
+    The state space is ``Discrete(14_400)`` = 25 taxi cells x 6 statuses per
+    passenger x 4 destinations per passenger (see module docstring for why
+    "delivered" is a sixth status, correcting docs/CADRAGE.md's 10,000).
+    """
+
+    # RUF012 suppressed: gymnasium's Env declares ``metadata`` as a plain
+    # mutable class attribute, so a ClassVar annotation would clash with it.
+    metadata = {"render_modes": ["ansi"], "render_fps": 4}  # noqa: RUF012
+
+    def __init__(self, render_mode: str | None = "ansi") -> None:
+        """Create the environment.
+
+        Args:
+            render_mode: Only ``"ansi"`` (string frames) is supported.
+        """
+        self.render_mode = render_mode
+        self.desc = np.asarray(MAP, dtype="c")
+        # cast: Discrete is Space[np.int64] in gymnasium's stubs while this
+        # env is typed over built-in int observations/actions.
+        self.observation_space = cast("Space[int]", Discrete(N_STATES))
+        self.action_space = cast("Space[int]", Discrete(N_ACTIONS))
+        # Deterministic placeholder state; reset() randomises it.
+        self._taxi_row = 0
+        self._taxi_col = 0
+        self._statuses = [0, 1]
+        self._dests = [1, 0]
+
+    # ------------------------------------------------------------------ properties
+
+    @property
+    def n_states(self) -> int:
+        """Number of discrete states (14,400)."""
+        return N_STATES
+
+    @property
+    def n_actions(self) -> int:
+        """Number of discrete actions (6)."""
+        return N_ACTIONS
+
+    # ------------------------------------------------------------------ core API
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[int, dict[str, Any]]:
+        """Sample a new initial state.
+
+        Taxi cell: uniform over the 25 cells. Passenger starts: two distinct
+        landmarks. Destinations: ``dest_i != start_i`` for each passenger
+        (destinations may coincide with each other).
+
+        Args:
+            seed: Seed for ``self.np_random`` (Gymnasium seeding semantics).
+            options: Unused (Gymnasium API compatibility).
+
+        Returns:
+            Tuple ``(state, info)``; ``info["decoded"]`` holds the decoded
+            component tuple for debugging.
+        """
+        super().reset(seed=seed)
+        self._taxi_row = int(self.np_random.integers(N_ROWS))
+        self._taxi_col = int(self.np_random.integers(N_COLS))
+        starts = self.np_random.choice(N_LOCATIONS, size=N_PASSENGERS, replace=False)
+        self._statuses = [int(start) for start in starts]
+        self._dests = [self._random_destination(start) for start in self._statuses]
+        state = self._encoded()
+        return state, {"decoded": decode(state)}
+
+    def step(self, action: int) -> tuple[int, float, bool, bool, dict[str, Any]]:
+        """Apply one action (deterministic transition).
+
+        Args:
+            action: 0 South, 1 North, 2 East, 3 West, 4 Pickup, 5 Dropoff.
+
+        Returns:
+            Tuple ``(state, reward, terminated, truncated, info)`` with
+            ``truncated`` always False (time limits are applied by wrappers)
+            and ``info["raw_reward"]`` always set to the native reward.
+        """
+        if action == 0:  # South
+            self._taxi_row = min(self._taxi_row + 1, N_ROWS - 1)
+            reward = MOVE_REWARD
+        elif action == 1:  # North
+            self._taxi_row = max(self._taxi_row - 1, 0)
+            reward = MOVE_REWARD
+        elif action == 2:  # East
+            if self.desc[1 + self._taxi_row, 2 * self._taxi_col + 2] == b":":
+                self._taxi_col += 1
+            reward = MOVE_REWARD
+        elif action == 3:  # West
+            if self.desc[1 + self._taxi_row, 2 * self._taxi_col] == b":":
+                self._taxi_col -= 1
+            reward = MOVE_REWARD
+        elif action == 4:  # Pickup
+            reward = self._pickup()
+        elif action == 5:  # Dropoff
+            reward = self._dropoff()
+        else:
+            raise ValueError(f"invalid action {action} (expected 0-5)")
+        terminated = all(status == STATUS_DELIVERED for status in self._statuses)
+        state = self._encoded()
+        info: dict[str, Any] = {"decoded": decode(state), "raw_reward": reward}
+        return state, reward, terminated, False, info
+
+    # type ignore: gymnasium types ``Env.render`` with an unbound ``RenderFrame``
+    # TypeVar, which a concrete ``str`` return cannot satisfy under mypy strict.
+    def render(self) -> str | None:  # type: ignore[override]
+        """Render the grid in Taxi-v3 style plus a passenger legend.
+
+        The taxi is drawn as ``T``, waiting passengers as ``1``/``2`` on
+        their cells; statuses and destinations are summarised in a final
+        legend line (e.g. ``P1: in taxi -> G | P2: at Y -> B``).
+        """
+        if self.render_mode != "ansi":
+            return None
+        grid = [list(line) for line in MAP]
+        for i, status in enumerate(self._statuses):
+            if status < N_LOCATIONS:
+                row, col = LOCATIONS[status]
+                grid[1 + row][2 * col + 1] = str(i + 1)
+        grid[1 + self._taxi_row][2 * self._taxi_col + 1] = "T"
+        legend = " | ".join(
+            f"P{i + 1}: {self._status_text(status)} -> {LOCATION_NAMES[dest]}"
+            for i, (status, dest) in enumerate(zip(self._statuses, self._dests, strict=True))
+        )
+        return "\n".join("".join(row) for row in grid) + "\n" + legend + "\n"
+
+    # ------------------------------------------------------------------ helpers
+
+    def decode_state(self, state: int) -> tuple[int, int, int, int, int, int]:
+        """Alias of module-level :func:`decode` (parity with TaxiEnvWrapper)."""
+        return decode(state)
+
+    def _encoded(self) -> int:
+        return encode(
+            self._taxi_row,
+            self._taxi_col,
+            self._statuses[0],
+            self._statuses[1],
+            self._dests[0],
+            self._dests[1],
+        )
+
+    def _set_state(
+        self, taxi_row: int, taxi_col: int, status_0: int, status_1: int, dest_0: int, dest_1: int
+    ) -> int:
+        """Force the internal state (test helper for scripted scenarios).
+
+        Returns:
+            The resulting encoded state.
+        """
+        self._taxi_row = taxi_row
+        self._taxi_col = taxi_col
+        self._statuses = [status_0, status_1]
+        self._dests = [dest_0, dest_1]
+        return self._encoded()
+
+    def _random_destination(self, start: int) -> int:
+        """Sample a destination uniformly over the three landmarks != start."""
+        dest = int(self.np_random.integers(N_LOCATIONS - 1))
+        return dest + 1 if dest >= start else dest
+
+    def _pickup(self) -> float:
+        """Board the lowest-index waiting passenger on the taxi cell, if any."""
+        cell = (self._taxi_row, self._taxi_col)
+        for i, status in enumerate(self._statuses):
+            if status < N_LOCATIONS and LOCATIONS[status] == cell:
+                self._statuses[i] = STATUS_IN_TAXI
+                return MOVE_REWARD
+        return ILLEGAL_REWARD
+
+    def _dropoff(self) -> float:
+        """Deliver the lowest-index in-taxi passenger destined here, if any."""
+        cell = (self._taxi_row, self._taxi_col)
+        if cell in LOCATIONS:
+            landmark = LOCATIONS.index(cell)
+            for i, status in enumerate(self._statuses):
+                if status == STATUS_IN_TAXI and self._dests[i] == landmark:
+                    self._statuses[i] = STATUS_DELIVERED
+                    return DELIVER_REWARD
+        return ILLEGAL_REWARD
+
+    @staticmethod
+    def _status_text(status: int) -> str:
+        if status == STATUS_IN_TAXI:
+            return "in taxi"
+        if status == STATUS_DELIVERED:
+            return "delivered"
+        return f"at {LOCATION_NAMES[status]}"
+
+
+class MultiEnvWrapper:
+    """Project-facing wrapper around a TimeLimit-wrapped MultiPassengerTaxiEnv.
+
+    Mirrors :class:`~src.environments.taxi_wrapper.TaxiEnvWrapper`'s public
+    surface — ``reset(seed)``/``step``/``render``/``close``, ``n_states``/
+    ``n_actions``/``decode_state`` and ``info["raw_reward"]`` — so the
+    Trainer, Evaluator and agent factory work unchanged. A dedicated wrapper
+    is required because gymnasium 1.x removed ``Wrapper.__getattr__``
+    delegation: ``TimeLimit(env).n_states`` raises AttributeError (only
+    ``observation_space``/``action_space``/``unwrapped`` pass through), so
+    custom attributes must be surfaced explicitly.
+
+    Seeding follows the same convention as TaxiEnvWrapper: the constructor
+    seed is applied on the first reset only; an explicit ``reset(seed=...)``
+    always re-seeds; bare resets continue the RNG stream.
+
+    Attributes:
+        env: The underlying Gymnasium environment (TimeLimit-wrapped).
+        reward_fn: Optional reward-shaping function applied on each step.
+    """
+
+    def __init__(
+        self,
+        reward_fn: RewardFn | None = None,
+        seed: int | None = None,
+        render_mode: str = "ansi",
+        max_steps: int = MULTI_MAX_STEPS,
+    ) -> None:
+        """Create the wrapped environment.
+
+        Args:
+            reward_fn: Optional shaping function ``(state, action, raw_reward,
+                next_state) -> shaped_reward``. When None, rewards pass through.
+            seed: Seed applied on the first :meth:`reset` only.
+            render_mode: Gymnasium render mode (``"ansi"`` yields strings).
+            max_steps: Episode step limit enforced via ``TimeLimit`` (500 by
+                default: two-passenger routes are ~2x Taxi-v3's, plus
+                early-training wandering).
+        """
+        self.env: gym.Env[int, int] = TimeLimit(
+            MultiPassengerTaxiEnv(render_mode=render_mode), max_episode_steps=max_steps
+        )
+        self.reward_fn = reward_fn
+        self._seed = seed
+        self._seeded = False
+        self._state = 0
+
+    # ------------------------------------------------------------------ properties
+
+    @property
+    def n_states(self) -> int:
+        """Number of discrete states (14,400)."""
+        space = self.env.observation_space
+        assert isinstance(space, Discrete)
+        # cast: numpy stubs make mypy infer ``Discrete.n`` as ``Any | np.void``.
+        return int(cast(SupportsInt, space.n))
+
+    @property
+    def n_actions(self) -> int:
+        """Number of discrete actions (6)."""
+        space = self.env.action_space
+        assert isinstance(space, Discrete)
+        return int(cast(SupportsInt, space.n))
+
+    # ------------------------------------------------------------------ core API
+
+    def reset(self, seed: int | None = None) -> tuple[int, dict[str, Any]]:
+        """Reset the environment and return the initial state.
+
+        Args:
+            seed: Explicit episode seed. When given it is passed through
+                (fixed evaluation episodes). Otherwise the constructor seed is
+                used on the first reset only; later resets are bare so the
+                RNG stream continues (Gymnasium 1.x seeding semantics).
+
+        Returns:
+            Tuple ``(state, info)`` with ``state`` as a built-in int.
+        """
+        if seed is not None:
+            obs, info = self.env.reset(seed=seed)
+        elif not self._seeded:
+            obs, info = self.env.reset(seed=self._seed)
+        else:
+            obs, info = self.env.reset()
+        self._seeded = True
+        self._state = int(obs)
+        return self._state, info
+
+    def step(self, action: int) -> tuple[int, float, bool, bool, dict[str, Any]]:
+        """Take one environment step, applying reward shaping when configured.
+
+        Args:
+            action: Discrete action index.
+
+        Returns:
+            Tuple ``(next_state, reward, terminated, truncated, info)``.
+            ``reward`` is the shaped reward when ``reward_fn`` is set; the
+            native environment reward is always stored in
+            ``info["raw_reward"]``.
+        """
+        state_before = self._state
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        next_state = int(obs)
+        raw_reward = float(reward)
+        info["raw_reward"] = raw_reward
+        shaped = (
+            raw_reward
+            if self.reward_fn is None
+            else self.reward_fn(state_before, action, raw_reward, next_state)
+        )
+        self._state = next_state
+        return next_state, float(shaped), bool(terminated), bool(truncated), info
+
+    def render(self) -> str:
+        """Return the current ANSI rendering of the environment."""
+        frame: Any = self.env.render()
+        return frame if isinstance(frame, str) else ""
+
+    def close(self) -> None:
+        """Release the underlying environment resources."""
+        self.env.close()
+
+    # ------------------------------------------------------------------ helpers
+
+    def decode_state(self, state: int) -> tuple[int, int, int, int, int, int]:
+        """Decode an encoded state into its components.
+
+        Args:
+            state: Encoded state in ``[0, n_states)``.
+
+        Returns:
+            Tuple ``(taxi_row, taxi_col, status_0, status_1, dest_0, dest_1)``.
+        """
+        return decode(state)

--- a/src/environments/route_analysis.py
+++ b/src/environments/route_analysis.py
@@ -1,0 +1,138 @@
+"""Route-order analysis for the multi-passenger environment (T-2.2.3).
+
+Brute-force enumeration of pickup/dropoff interleavings to compute the
+minimal-distance route for a state, and a greedy nearest-passenger baseline.
+Distances are Manhattan distances that **ignore walls**, so route lengths are
+a heuristic lower bound on the true step counts. With two passengers there
+are at most six valid interleavings (pickups before their dropoffs; taxi
+capacity 2 never binds), so enumeration is exact and instant.
+
+The report uses these to analyse the learned policy's route optimisation:
+does the trained agent pick the nearest passenger first, and does it match
+the enumerated optimal visit order?
+"""
+
+from __future__ import annotations
+
+from itertools import permutations
+from operator import itemgetter
+
+from src.environments.multi_passenger_env import LOCATIONS, N_LOCATIONS, STATUS_IN_TAXI, decode
+
+Cell = tuple[int, int]
+#: One route event: ``(passenger_index, phase, cell)``.
+Event = tuple[int, int, Cell]
+
+PICKUP = 0
+DROPOFF = 1
+
+
+def optimal_pickup_order(state: int) -> tuple[int, ...]:
+    """Pickup order of a minimal-Manhattan-distance route for ``state``.
+
+    All valid event interleavings (each pickup before its dropoff; capacity 2
+    allows any interleaving) are enumerated and the cheapest route is kept.
+    Ties favour the lowest passenger index first (deterministic enumeration
+    order). Distances ignore walls (heuristic lower bound).
+
+    Args:
+        state: Encoded state; passengers already in the taxi contribute only
+            their dropoff, delivered passengers contribute nothing.
+
+    Returns:
+        Passenger indices in optimal pickup order (may be empty or length 1).
+    """
+    _, sequence = _best_route(state)
+    return tuple(passenger for passenger, phase, _ in sequence if phase == PICKUP)
+
+
+def greedy_nearest_order(state: int) -> tuple[int, ...]:
+    """Pickup order from repeatedly driving to the nearest waiting passenger.
+
+    Starting from the taxi cell, the nearest waiting passenger (ties: lowest
+    index) is visited, then the next nearest from there, and so on. This is
+    the myopic baseline the report compares against the enumerated optimum.
+
+    Args:
+        state: Encoded state; only waiting passengers (status 0-3) count.
+
+    Returns:
+        Passenger indices in greedy pickup order (may be empty or length 1).
+    """
+    taxi_row, taxi_col, status_0, status_1, _, _ = decode(state)
+    position: Cell = (taxi_row, taxi_col)
+    waiting = {
+        i: LOCATIONS[status]
+        for i, status in enumerate((status_0, status_1))
+        if status < N_LOCATIONS
+    }
+    order: list[int] = []
+    while waiting:
+        _, nearest = min((_manhattan(position, cell), i) for i, cell in waiting.items())
+        order.append(nearest)
+        position = waiting.pop(nearest)
+    return tuple(order)
+
+
+def min_route_length(state: int) -> int:
+    """Minimal Manhattan route length for ``state`` (walls ignored).
+
+    An optimistic lower bound on the steps an optimal policy needs from
+    ``state`` (pickup/dropoff actions are not counted, only moves).
+    """
+    cost, _ = _best_route(state)
+    return cost
+
+
+# ---------------------------------------------------------------------- internals
+
+
+def _manhattan(a: Cell, b: Cell) -> int:
+    return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+
+def _remaining_events(state: int) -> tuple[Cell, list[Event]]:
+    """Taxi cell and the pickup/dropoff events still to perform in ``state``."""
+    taxi_row, taxi_col, status_0, status_1, dest_0, dest_1 = decode(state)
+    events: list[Event] = []
+    for i, (status, dest) in enumerate(((status_0, dest_0), (status_1, dest_1))):
+        if status < N_LOCATIONS:
+            events.append((i, PICKUP, LOCATIONS[status]))
+            events.append((i, DROPOFF, LOCATIONS[dest]))
+        elif status == STATUS_IN_TAXI:
+            events.append((i, DROPOFF, LOCATIONS[dest]))
+    return (taxi_row, taxi_col), events
+
+
+def _is_valid(sequence: tuple[Event, ...]) -> bool:
+    """True when every passenger's pickup precedes their dropoff."""
+    needs_pickup = {passenger for passenger, phase, _ in sequence if phase == PICKUP}
+    picked: set[int] = set()
+    for passenger, phase, _ in sequence:
+        if phase == PICKUP:
+            picked.add(passenger)
+        elif passenger in needs_pickup and passenger not in picked:
+            return False
+    return True
+
+
+def _route_length(start: Cell, sequence: tuple[Event, ...]) -> int:
+    total = 0
+    position = start
+    for _, _, cell in sequence:
+        total += _manhattan(position, cell)
+        position = cell
+    return total
+
+
+def _best_route(state: int) -> tuple[int, tuple[Event, ...]]:
+    """Cheapest valid event sequence for ``state`` (first minimum wins)."""
+    start, events = _remaining_events(state)
+    candidates = (
+        (_route_length(start, sequence), sequence)
+        for sequence in permutations(events)
+        if _is_valid(sequence)
+    )
+    # min() is stable: among equal costs the earliest enumerated sequence wins,
+    # which (events being listed passenger-0 first) favours the lowest index.
+    return min(candidates, key=itemgetter(0))

--- a/src/evaluation/evaluator.py
+++ b/src/evaluation/evaluator.py
@@ -12,7 +12,7 @@ from src.evaluation.metrics import EvalResults, compute_eval_results
 
 if TYPE_CHECKING:
     from src.agents.base_agent import BaseAgent
-    from src.environments.taxi_wrapper import TaxiEnvWrapper
+    from src.environments import EnvWrapper
 
 ACTION_NAMES = ("South", "North", "East", "West", "Pickup", "Dropoff")
 
@@ -25,7 +25,7 @@ class Evaluator:
     for fair pairwise comparisons and the statistical protocol.
     """
 
-    def __init__(self, env: TaxiEnvWrapper, seeds: list[int] | None = None) -> None:
+    def __init__(self, env: EnvWrapper, seeds: list[int] | None = None) -> None:
         self.env = env
         self.seeds = seeds
 

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
     from src.agents.base_agent import BaseAgent
     from src.config import Config
-    from src.environments.taxi_wrapper import TaxiEnvWrapper
+    from src.environments import EnvWrapper
 
 
 @dataclass
@@ -93,10 +93,10 @@ class Trainer:
     def __init__(
         self,
         agent: BaseAgent,
-        env: TaxiEnvWrapper,
+        env: EnvWrapper,
         config: Config,
         callbacks: list[Callback] | None = None,
-        probe_env: TaxiEnvWrapper | None = None,
+        probe_env: EnvWrapper | None = None,
     ) -> None:
         self.agent = agent
         self.env = env

--- a/tests/environments/test_multi_passenger_env.py
+++ b/tests/environments/test_multi_passenger_env.py
@@ -1,0 +1,291 @@
+"""Tests for the 2-passenger env: encoding, transitions, TimeLimit, training."""
+
+import warnings
+
+import numpy as np
+import pytest
+from gymnasium.utils.env_checker import check_env
+
+from src.agents import create_agent
+from src.config import Config
+from src.environments import create_env
+from src.environments.multi_passenger_env import (
+    N_ACTIONS,
+    N_STATES,
+    STATUS_DELIVERED,
+    STATUS_IN_TAXI,
+    MultiEnvWrapper,
+    MultiPassengerTaxiEnv,
+    decode,
+    encode,
+)
+from src.environments.route_analysis import (
+    greedy_nearest_order,
+    min_route_length,
+    optimal_pickup_order,
+)
+from src.training.trainer import Trainer
+
+# Landmark indices, for readable scenario set-ups.
+R, G, Y, B = 0, 1, 2, 3
+
+
+@pytest.fixture()
+def raw() -> MultiPassengerTaxiEnv:
+    return MultiPassengerTaxiEnv()
+
+
+class TestEncoding:
+    def test_sizes(self) -> None:
+        assert N_STATES == 14_400
+        assert N_ACTIONS == 6
+
+    def test_bijection_over_all_states(self) -> None:
+        for state in range(N_STATES):
+            row, col, s0, s1, d0, d1 = decode(state)
+            assert 0 <= row < 5 and 0 <= col < 5
+            assert 0 <= s0 < 6 and 0 <= s1 < 6
+            assert 0 <= d0 < 4 and 0 <= d1 < 4
+            assert encode(row, col, s0, s1, d0, d1) == state
+
+    def test_extreme_states(self) -> None:
+        assert encode(0, 0, 0, 0, 0, 0) == 0
+        assert encode(4, 4, 5, 5, 3, 3) == N_STATES - 1
+
+
+class TestReset:
+    def test_invariants_over_200_seeded_resets(self, raw: MultiPassengerTaxiEnv) -> None:
+        for seed in range(200):
+            state, info = raw.reset(seed=seed)
+            assert type(state) is int
+            row, col, s0, s1, d0, d1 = decode(state)
+            assert info["decoded"] == (row, col, s0, s1, d0, d1)
+            assert 0 <= row < 5 and 0 <= col < 5
+            assert 0 <= s0 <= 3 and 0 <= s1 <= 3  # both waiting at a landmark
+            assert s0 != s1  # distinct start locations
+            assert d0 != s0 and d1 != s1  # dest differs from own start
+
+    def test_same_seed_same_initial_state(self, raw: MultiPassengerTaxiEnv) -> None:
+        s1, _ = raw.reset(seed=42)
+        s2, _ = raw.reset(seed=42)
+        assert s1 == s2
+        assert MultiPassengerTaxiEnv().reset(seed=42)[0] == s1
+
+
+class TestWrapperSeeding:
+    def test_same_constructor_seed_same_first_reset(self) -> None:
+        s1, _ = MultiEnvWrapper(seed=7).reset()
+        s2, _ = MultiEnvWrapper(seed=7).reset()
+        assert s1 == s2
+
+    def test_explicit_seed_reproducible_mid_sequence(self) -> None:
+        env = MultiEnvWrapper(seed=42)
+        s1, _ = env.reset(seed=123)
+        env.step(0)
+        env.reset()  # advance the RNG stream mid-sequence
+        s2, _ = env.reset(seed=123)
+        assert s1 == s2
+
+    def test_bare_resets_do_not_reseed(self) -> None:
+        env = MultiEnvWrapper(seed=42)
+        states = [env.reset()[0] for _ in range(5)]
+        assert len(set(states)) > 1
+
+
+class TestPickup:
+    def test_lowest_index_wins_when_both_eligible(self, raw: MultiPassengerTaxiEnv) -> None:
+        # Impossible at reset (distinct starts): forced via _set_state.
+        raw._set_state(0, 0, R, R, G, Y)
+        state, reward, terminated, truncated, _ = raw.step(4)
+        _, _, s0, s1, _, _ = decode(state)
+        assert (s0, s1) == (STATUS_IN_TAXI, R)
+        assert reward == -1.0
+        assert not terminated and not truncated
+
+    def test_illegal_pickup_empty_cell(self, raw: MultiPassengerTaxiEnv) -> None:
+        before = raw._set_state(2, 2, R, Y, G, B)
+        state, reward, *_ = raw.step(4)
+        assert reward == -10.0
+        assert state == before  # nothing changed
+
+    def test_second_pickup_puts_both_in_taxi(self, raw: MultiPassengerTaxiEnv) -> None:
+        raw._set_state(0, 0, R, G, G, R)
+        raw.step(4)  # picks P1 at R
+        raw._set_state(0, 4, STATUS_IN_TAXI, G, G, R)  # drive to G
+        state, reward, *_ = raw.step(4)
+        _, _, s0, s1, _, _ = decode(state)
+        assert (s0, s1) == (STATUS_IN_TAXI, STATUS_IN_TAXI)  # capacity 2
+        assert reward == -1.0
+
+
+class TestDropoff:
+    def test_dropoff_at_destination_delivers(self, raw: MultiPassengerTaxiEnv) -> None:
+        raw._set_state(0, 4, STATUS_IN_TAXI, Y, G, B)  # taxi at G, P1 destined G
+        state, reward, terminated, *_ = raw.step(5)
+        _, _, s0, s1, _, _ = decode(state)
+        assert s0 == STATUS_DELIVERED
+        assert s1 == Y
+        assert reward == 20.0
+        assert not terminated  # P2 still waiting
+
+    def test_second_delivery_terminates(self, raw: MultiPassengerTaxiEnv) -> None:
+        raw._set_state(4, 3, STATUS_DELIVERED, STATUS_IN_TAXI, G, B)  # taxi at B
+        state, reward, terminated, truncated, _ = raw.step(5)
+        _, _, s0, s1, _, _ = decode(state)
+        assert (s0, s1) == (STATUS_DELIVERED, STATUS_DELIVERED)
+        assert reward == 20.0
+        assert terminated and not truncated
+
+    def test_illegal_dropoff_off_landmark(self, raw: MultiPassengerTaxiEnv) -> None:
+        before = raw._set_state(2, 2, STATUS_IN_TAXI, Y, G, B)
+        state, reward, *_ = raw.step(5)
+        assert reward == -10.0
+        assert state == before
+
+    def test_setdown_forbidden_at_wrong_landmark(self, raw: MultiPassengerTaxiEnv) -> None:
+        # Taxi on Y, P1 in taxi destined G: Taxi-v3 would set the passenger
+        # down for -1; here the set-down is forbidden (-10, passenger stays).
+        before = raw._set_state(4, 0, STATUS_IN_TAXI, R, G, B)
+        state, reward, *_ = raw.step(5)
+        assert reward == -10.0
+        assert state == before
+        assert decode(state)[2] == STATUS_IN_TAXI
+
+    def test_same_destination_needs_two_dropoffs(self, raw: MultiPassengerTaxiEnv) -> None:
+        raw._set_state(0, 4, STATUS_IN_TAXI, STATUS_IN_TAXI, G, G)  # both destined G
+        state, reward, terminated, *_ = raw.step(5)
+        _, _, s0, s1, _, _ = decode(state)
+        assert (s0, s1) == (STATUS_DELIVERED, STATUS_IN_TAXI)  # lowest index first
+        assert reward == 20.0 and not terminated
+        state, reward, terminated, *_ = raw.step(5)
+        _, _, s0, s1, _, _ = decode(state)
+        assert (s0, s1) == (STATUS_DELIVERED, STATUS_DELIVERED)
+        assert reward == 20.0 and terminated
+
+
+class TestMoves:
+    def test_wall_blocks_east_from_0_1(self, raw: MultiPassengerTaxiEnv) -> None:
+        # MAP row 0 has a "|" between columns 1 and 2 ("|R: | : :G|").
+        raw._set_state(0, 1, R, Y, G, B)
+        state, reward, terminated, *_ = raw.step(2)
+        assert decode(state)[:2] == (0, 1)  # position unchanged
+        assert reward == -1.0 and not terminated
+
+    def test_border_clamps_north(self, raw: MultiPassengerTaxiEnv) -> None:
+        raw._set_state(0, 2, R, Y, G, B)
+        state, reward, *_ = raw.step(1)
+        assert decode(state)[:2] == (0, 2)
+        assert reward == -1.0
+
+    def test_open_move_south(self, raw: MultiPassengerTaxiEnv) -> None:
+        raw._set_state(0, 2, R, Y, G, B)
+        state, reward, *_ = raw.step(0)
+        assert decode(state)[:2] == (1, 2)
+        assert reward == -1.0
+
+
+class TestRender:
+    def test_ansi_grid_and_legend(self, raw: MultiPassengerTaxiEnv) -> None:
+        raw._set_state(2, 2, R, Y, G, B)
+        frame = raw.render()
+        assert isinstance(frame, str)
+        assert "+---------+" in frame
+        assert "T" in frame
+        assert "1" in frame and "2" in frame  # waiting passengers on their cells
+        assert "P1: at R -> G | P2: at Y -> B" in frame
+
+    def test_in_taxi_legend(self, raw: MultiPassengerTaxiEnv) -> None:
+        raw._set_state(2, 2, STATUS_IN_TAXI, Y, G, B)
+        frame = raw.render()
+        assert frame is not None
+        assert "P1: in taxi -> G" in frame
+
+
+class TestFactoryAndTimeLimit:
+    def test_create_env_multi_returns_wrapper(self) -> None:
+        env = create_env(Config(env="multi", seed=7))
+        assert isinstance(env, MultiEnvWrapper)
+        assert env.n_states == 14_400
+        assert env.n_actions == 6
+        assert type(env.n_states) is int
+
+    def test_truncates_at_500_pure_moves(self) -> None:
+        env = create_env(Config(env="multi", seed=7))
+        env.reset()
+        terminated = truncated = False
+        steps = 0
+        while not (terminated or truncated):
+            _, _, terminated, truncated, _ = env.step(0)  # moving never terminates
+            steps += 1
+        assert steps == 500
+        assert truncated and not terminated
+
+    def test_step_surface_matches_taxi_wrapper(self) -> None:
+        env = create_env(Config(env="multi", seed=7))
+        state, info = env.reset()
+        assert type(state) is int and isinstance(info, dict)
+        next_state, reward, terminated, truncated, info = env.step(0)
+        assert type(next_state) is int and type(reward) is float
+        assert type(terminated) is bool and type(truncated) is bool
+        assert info["raw_reward"] == reward
+
+    def test_reward_fn_passthrough(self) -> None:
+        env = create_env(Config(env="multi", seed=7), reward_fn=lambda s, a, r, s2: r + 1.0)
+        env.reset()
+        _, reward, _, _, info = env.step(0)
+        assert reward == info["raw_reward"] + 1.0
+
+    def test_wrapper_decode_state(self) -> None:
+        env = create_env(Config(env="multi", seed=7))
+        assert isinstance(env, MultiEnvWrapper)
+        state, _ = env.reset()
+        assert env.decode_state(state) == decode(state)
+
+
+class TestEnvChecker:
+    def test_gymnasium_check_env_passes(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            check_env(MultiPassengerTaxiEnv())
+
+
+class TestTrainerIntegration:
+    def test_q_learning_trains_300_episodes(self) -> None:
+        config = Config(env="multi", algorithm="q_learning", seed=3, n_train_episodes=300)
+        env = create_env(config)
+        agent = create_agent(config, env, n_episodes=config.n_train_episodes)
+        history = Trainer(agent, env, config).train(config.n_train_episodes)
+        assert len(history.rewards) == 300
+        q_table = agent.q_table  # type: ignore[attr-defined]
+        assert q_table.shape == (14_400, 6)
+        assert np.count_nonzero(q_table) > 0
+
+
+class TestRouteAnalysis:
+    def test_hand_computed_symmetric_case(self) -> None:
+        # Taxi (2,2); P1 R->G, P2 Y->B. Enumerated by hand (Manhattan, no walls):
+        #   p1 d1 p2 d2: 4+4+8+3 = 19    p1 p2 d1 d2: 4+4+8+5 = 21
+        #   p1 p2 d2 d1: 4+4+3+5 = 16 *  p2 d2 p1 d1: 4+3+7+4 = 18
+        #   p2 p1 d2 d1: 4+4+7+5 = 20    p2 p1 d1 d2: 4+4+4+5 = 17
+        state = encode(2, 2, R, Y, G, B)
+        assert optimal_pickup_order(state) == (0, 1)
+        assert min_route_length(state) == 16
+        assert greedy_nearest_order(state) == (0, 1)  # tie (4 vs 4) -> lowest index
+
+    def test_hand_computed_asymmetric_case(self) -> None:
+        # Taxi (3,0); P1 R->G, P2 Y->B. Best: p2 p1 d1 d2 = 1+4+4+5 = 14.
+        state = encode(3, 0, R, Y, G, B)
+        assert optimal_pickup_order(state) == (1, 0)
+        assert min_route_length(state) == 14
+        assert greedy_nearest_order(state) == (1, 0)  # Y (dist 1) closer than R (3)
+
+    def test_in_taxi_passenger_contributes_dropoff_only(self) -> None:
+        state = encode(0, 0, STATUS_IN_TAXI, Y, G, B)
+        assert optimal_pickup_order(state) == (1,)
+        assert greedy_nearest_order(state) == (1,)
+
+    def test_all_delivered_empty_orders(self) -> None:
+        state = encode(0, 0, STATUS_DELIVERED, STATUS_DELIVERED, G, B)
+        assert optimal_pickup_order(state) == ()
+        assert greedy_nearest_order(state) == ()
+        assert min_route_length(state) == 0

--- a/tests/environments/test_taxi_wrapper.py
+++ b/tests/environments/test_taxi_wrapper.py
@@ -147,7 +147,3 @@ class TestFactory:
         _, reward, _, _, info = env.step(0)
         assert reward == 0.0
         assert info["raw_reward"] != 0.0
-
-    def test_create_env_multi_not_implemented(self) -> None:
-        with pytest.raises(NotImplementedError, match="multi-passenger"):
-            create_env(Config(env="multi"))


### PR DESCRIPTION
## Description
Implements the subject's extension ("the taxi collects 2 people…, the goal being to optimize the route") per T-2.2.1..3:

- **State space 25×6²×4² = 14,400**: per-passenger status {R,G,Y,B,in_taxi,**delivered**} — corrects docs/CADRAGE.md's 10,000 figure, which omitted the delivered status (with two passengers, the first delivery doesn't end the episode). Mixed-radix encode/decode, bijection tested over all 14,400 states
- Same 5×5 map/walls as Taxi-v3; capacity 2 (both passengers can ride — required for genuine route optimization); deterministic lowest-index-wins pickup/dropoff; mid-episode set-down forbidden (−10, documented divergence); +20 per correct delivery; terminal when both delivered; TimeLimit 500 via factory
- **API finding**: gymnasium 1.2 `TimeLimit` does NOT delegate custom attributes (`Wrapper.__getattr__` removed in 1.0) → thin `MultiEnvWrapper` mirrors the TaxiEnvWrapper surface (first-reset seeding, `info["raw_reward"]`, n_states/n_actions/decode_state); shared structural `EnvWrapper` Protocol now types Trainer/Evaluator (zero logic changes)
- `route_analysis.py`: exact brute-force optimal pickup/drop interleaving (Manhattan lower bound) + greedy-nearest baseline — feeds the report's route-optimization analysis (H9)
- `--env multi` wired into the factory and CLI

## Tests effectués
32 nouveaux tests : bijection complète, invariants de reset (200 seeds), scénarios de transition scriptés (pickup/dropoff légaux et illégaux, double dépose même destination, murs, terminaison), `check_env` gymnasium, truncation à 500, entraînement Q-Learning 300 épisodes avec Q-table (14400, 6), cas d'analyse de route énumérés à la main. Local : ruff ✅ black ✅ mypy strict ✅ pytest 161/161 ✅.

## Issues liées
Closes #46 (T-2.2.1), Closes #47 (T-2.2.2), Closes #48 (T-2.2.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)