### PR TITLE
feat(benchmark): experiment runner, statistics, figures and E0-E7 campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/)
   au lancement), mode time-limited (config optimisée, budget temps 90/10),
   auto-détection de l'algorithme depuis les métadonnées du modèle ; smoke test CI
 
+- Benchmarking scientifique : runner d'expériences idempotent (hash de config,
+  reprise après crash), module statistique (Shapiro→Welch/Mann-Whitney, Holm,
+  Hedges g, Cliff δ), reward shaping (potentiel/naïf/pénalité), R* par value
+  iteration, sous-commandes `benchmark`/`compare`, campagne E0-E7
+  (`scripts/run_campaign.py`), protocole expérimental (`docs/PROTOCOLE.md`)
+- Visualisation : générateurs de figures F1-F12 pilotés par les données
+  (`scripts/make_figures.py`), GIF d'épisode, instrumentation max-Q des sondes
+
 ### Changed
 
 - `.gitignore` : les modèles finaux (`models/final/`) et les résultats agrégés/figures

--- a/configs/benchmark_sweep.yaml
+++ b/configs/benchmark_sweep.yaml
@@ -1,0 +1,29 @@
+# Grid-search definition consumed by `taxi-driver benchmark`.
+# Mirrors block E1a of docs/PROTOCOLE.md: 5 alpha x 4 gamma x 10 seeds.
+#
+# Notes (protocol §9):
+# - n_seeds is 10 (CADRAGE §6.5); reduce only for exploratory sweeps.
+# - epsilon decay is expressed as a horizon fraction (decay_frac) so that the
+#   sweep varies the decay SHAPE, not the total exploration budget.
+# - early stopping stays disabled: stopping some configurations earlier than
+#   others would bias every convergence metric.
+
+exp_id: sweep
+algorithms: [q_learning]
+n_seeds: 10
+seed_base: 42
+
+base:
+  n_train_episodes: 15000
+  n_test_episodes: 100
+  eval_interval: 100
+  n_probe_episodes: 30
+  epsilon: 1.0
+  epsilon_min: 0.01
+  decay_type: exp
+  decay_frac: 0.6
+  early_stopping: false
+
+sweep:
+  alpha: [0.05, 0.1, 0.15, 0.2, 0.3]
+  gamma: [0.9, 0.95, 0.99, 0.999]

--- a/docs/PROTOCOLE.md
+++ b/docs/PROTOCOLE.md
@@ -1,0 +1,113 @@
+# Protocole expérimental — Taxi Driver (T-AIA-902)
+
+> Ce document fixe le protocole scientifique du projet : conventions, hypothèses,
+> matrice d'expériences, méthodologie statistique et gestion des données. Toute
+> figure du rapport doit être régénérable depuis `results/raw/` en appliquant
+> ce protocole. Implémentation : `src/benchmarking/` et `scripts/run_campaign.py`.
+
+## 1. Conventions globales
+
+| Élément | Valeur | Justification |
+|---|---|---|
+| Seeds d'entraînement | 42..51 (n=10 par configuration) | CADRAGE §6.5 |
+| Évaluation finale | 100 épisodes, seeds figés `10042+i` identiques pour tous les agents | comparaisons appariées équitables |
+| Sondes de convergence | 30 épisodes greedy, seeds `20042+i` (disjoints de l'éval), toutes les 100 épisodes d'entraînement | mesurer la vraie politique sans contaminer l'évaluation ; le reward d'entraînement est confondu avec ε |
+| Politique de test | greedy stricte (ε=0), argmax déterministe (plus petit indice) | comparabilité |
+| Récompense rapportée | toujours la récompense **native** (`info["raw_reward"]`), même si le shaping est actif | le shaping ne doit pas gonfler les métriques |
+| Budget tabulaire / DQN / multi | 15 000 / 5 000 / 150 000 épisodes | dimensionné sur la convergence observée |
+| Early stopping | **désactivé** pour toutes les expériences (réservé au mode time-limited du CLI) | arrêter certains algos plus tôt biaise toutes les métriques de convergence |
+| Décroissance de ε | paramétrée en **fraction d'horizon** : ε atteint ε_min à 60 % de N | découple la forme de la décroissance du nombre d'épisodes |
+| Config de référence | α=0.15, γ=0.99, ε 1.0→0.01 (exp, frac 0.6) | point central des analyses de sensibilité |
+| R\* (étalon) | value iteration sur le modèle exact de Taxi-v3 (`env.P`), évalué sur les mêmes seeds | uniquement un instrument de mesure ; les agents restent model-free |
+| Seuil de convergence | reward sonde ≥ 0,9·R\* maintenu 3 checkpoints consécutifs ; censuré à N sinon | CADRAGE §6.5 (le 95 % de §6.2 est reporté en annexe) |
+| Unité statistique | le **run** (une seed), jamais l'épisode | éviter la pseudo-réplication |
+| Chronométrage | uniquement le bloc E7 (séquentiel, machine au repos) ; médiane rapportée en plus de la moyenne (variance WSL2) | mesures de temps fiables |
+
+## 2. Hypothèses testées
+
+| ID | Hypothèse (prédiction) | Métriques | Test |
+|---|---|---|---|
+| H1 | γ=0.99 converge plus lentement que γ=0.9 mais donne une meilleure politique finale (contre-prédiction discutée : épisodes courts ⇒ γ=0.9 peut suffire) | épisodes-au-seuil, reward final | Welch/M-W + Holm |
+| H2 | Q-Learning atteint le seuil plus tôt ; SARSA est plus stable pendant l'exploration | épisodes-au-seuil ; σ du reward d'entraînement | Welch/M-W + Holm |
+| H3 | Les résultats sont plus sensibles aux hyperparamètres qu'au choix d'algorithme | étendues intra vs inter-algos, η² descriptif | effect sizes + bootstrap |
+| H4 | Décroissance linéaire ≈ exponentielle en final ; Boltzmann converge au moins aussi vite ; UCB couvre mieux (s,a) au début mais sensible à c | épisodes-au-seuil, first-success, couverture (s,a) | paires vs référence + Holm |
+| H5 | Le shaping **basé potentiel** (Ng et al. 1999) accélère sans dégrader le reward natif final ; le bonus naïf dégrade ; la sur-pénalité de step est neutre à négative | épisodes-au-seuil et reward final **natifs** | paires vs native + Holm ; CI de la différence pour la non-infériorité |
+| H6 | Le tabulaire domine le DQN en efficacité échantillon (≥5×), temps (≥50×), mémoire, latence, à performance finale comparable | courbes vs env-steps cumulés, temps E7, mémoire | Welch/M-W + ratios descriptifs |
+| H7 | Double Q-Learning réduit le biais de surestimation (E[max Q] − retour réel), converge un peu plus lentement | gap de surestimation, épisodes-au-seuil | Welch/M-W + Holm |
+| H8 | Monte Carlo est plus lent et plus variable que les méthodes TD (runs censurés possibles) | épisodes-au-seuil censuré, taux de convergence | Mann-Whitney (rang pire pour censurés) |
+| H9 (exploratoire) | Multi-passagers (14 400 états) : croissance sur-linéaire du coût de convergence ; le classement QL>SARSA persiste | épisodes-au-seuil relatif | descriptif |
+
+## 3. Matrice d'expériences (~840 runs, ≈4 h 30 – 5 h 30 sur 6 cœurs)
+
+| Bloc | Contenu | Runs | Alimente |
+|---|---|---|---|
+| E0 | BruteForce, caps 200 et 2000 steps, 1000 épisodes d'éval | 20 | T1, ratio ~20×, artefact de troncature |
+| E1a | Grid QL : α∈{0.05,0.1,0.15,0.2,0.3} × γ∈{0.9,0.95,0.99,0.999} | 200 | H1, H3, F5/F6, `optimized.yaml` |
+| E1b | Grille croisée : {SARSA, ExpSARSA, DoubleQL, MC} × 3α × 3γ | 360 | H3 |
+| E2 | Face-à-face : 6 tabulaires + DQN à la config de référence | 70 | T1, H2/H6/H7/H8, F1-F4, F9 |
+| E3 | Exploration : ε-exp, ε-lin, Boltzmann, UCB | 40 | H4, F7 |
+| E4 | Shaping : native, potentiel, naïf, step-penalty | 40 | H5, F8 |
+| E5 | Sensibilité DQN : lr × hidden (5 seeds) | 30 | annexe DQN |
+| E6 | Multi-passagers : QL, SARSA × 150 000 épisodes | 20 | H9, F12 |
+| E7 | **Chronométrage séquentiel** : 6 algos × 10 seeds + DQN cuda/cpu × 3 | 66 | colonnes temps/mémoire de T1, ablation GPU |
+
+Parallélisation : E0–E6 via `multiprocessing.Pool(6)` (la parallélisation n'affecte
+pas reward/steps/épisodes ; « pas de parallélisation » du CADRAGE ne concerne que
+les mesures de temps → E7). Ordre de coupe si dépassement : E5 → E6-SARSA → E1b →
+seeds E3/E4 10→5. **E2 n'est jamais coupé.**
+
+## 4. Équité des comparaisons
+
+Trois axes rapportés, aucun algorithme n'est arrêté plus tôt qu'un autre :
+1. **épisodes égaux** (tabulaires entre eux : 15 000) ;
+2. **env-steps cumulés égaux** (tabulaire vs DQN, axe principal de H6) ;
+3. **wall-clock égal** (annexe, extrait de E7).
+
+La politique évaluée est celle de **fin d'entraînement** (pas de « meilleur
+checkpoint », qui favoriserait les algorithmes bruités). BruteForce : la moyenne
+(~−700) est un artefact de troncature à 200 steps — médiane, taux de succès et
+variante 2000 steps sont rapportés.
+
+## 5. Méthodologie statistique
+
+1. Échantillons = agrégats par run (n=10).
+2. Shapiro-Wilk (α=0.05) sur chaque groupe → deux normaux : **Welch** ; sinon
+   **Mann-Whitney U**. À n=10 la puissance de Shapiro-Wilk est faible : si les
+   deux tests divergent sur la significativité, les deux p sont rapportés.
+3. Comparaisons multiples : **Holm-Bonferroni par famille d'hypothèses** ;
+   p brut ET p ajusté rapportés.
+4. Tailles d'effet : **Hedges g** (Welch) et **Cliff's δ** (M-W).
+5. IC 95 % de Student : μ ± t₀.₉₇₅,ₙ₋₁·σ/√n.
+6. Format : « QL : 7.92 ± 0.31 (IC 95 % [7.70 ; 8.14], n=10) vs SARSA : … ;
+   Welch, p=0.008 (p_Holm=0.016), g=1.28 (effet fort) ».
+7. Non-significativité : rapporter l'IC de la différence, jamais « pas de
+   différence » (absence de preuve ≠ preuve d'absence).
+8. Métriques censurées (épisodes-au-seuil non atteint) : M-W avec rang pire +
+   taux de convergence rapporté.
+
+## 6. Gestion des données
+
+```
+results/
+├── r_star.json                      # étalon optimal (value iteration)
+├── raw/<bloc>/<algo>__<hash8>__s<seed>__<horodatage>/
+│   ├── config.json                  # config résolue + versions des libs
+│   ├── train_episodes.csv           # 1 ligne / épisode d'entraînement
+│   ├── probes.csv                   # 1 ligne / checkpoint de sonde
+│   ├── eval_episodes.csv            # 1 ligne / épisode d'évaluation (seed figé)
+│   └── summary.json                 # agrégats
+├── aggregated/<bloc>__runs.csv      # 1 ligne / run (consommé par les figures)
+└── figures/                         # PNG 300 dpi versionnés
+```
+
+`hash8` = SHA-256 tronqué de la configuration canonique **hors seed** : une même
+configuration garde le même hash à travers les seeds. Les runs sont idempotents
+par `(bloc, hash, seed)` : relancer la campagne reprend après un crash.
+
+## 7. Spécifications machine (T5 du rapport)
+
+CPU 6 cœurs, 27 Go RAM, GPU NVIDIA RTX 2060 6 Go (torch 2.5.1+cu124), WSL2,
+Python 3.10.12, gymnasium 1.2.3 (Taxi-v3 ; retiré de gymnasium ≥1.3, remplacé
+par Taxi-v4 identique aux paramètres par défaut — d'où le pin `<1.3`).
+Versions exactes loguées dans chaque `config.json`. Les temps sous WSL2 ont une
+variance élevée : médianes rapportées en complément des moyennes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ target-version = "py310"
 select = ["E", "W", "F", "I", "N", "UP", "B", "C4", "SIM", "RUF"]
 # E501: line length is enforced by black (strings/comments excepted by convention)
 ignore = ["E501"]
-# RL update rules in docstrings legitimately use mathematical notation.
-allowed-confusables = ["α", "γ", "ε", "π", "−", "×"]
+# RL update rules and French figure labels legitimately use mathematical notation.
+allowed-confusables = ["α", "γ", "ε", "π", "σ", "δ", "−", "×"]
 
 [tool.black]
 line-length = 100

--- a/scripts/make_figures.py
+++ b/scripts/make_figures.py
@@ -20,11 +20,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-import numpy as np  # noqa: E402
-import pandas as pd  # noqa: E402
+import numpy as np
+import pandas as pd
 
-from src.evaluation.metrics import mean_ci95  # noqa: E402
-from src.visualization import plots  # noqa: E402
+from src.evaluation.metrics import mean_ci95
+from src.visualization import plots
 
 ALGO_LABELS = {
     "brute_force": "BruteForce",
@@ -249,10 +249,12 @@ def fig_f11(results: Path, out: Path) -> None:
     candidates = [d for d in _run_dirs(results, "e2") if _algo_of(d) == "q_learning"]
     if not candidates:
         return
-    best = max(
-        candidates,
-        key=lambda d: json.load(open(d / "summary.json"))["eval_mean_reward"],
-    )
+
+    def _eval_reward(run_dir: Path) -> float:
+        with open(run_dir / "summary.json") as handle:
+            return float(json.load(handle)["eval_mean_reward"])
+
+    best = max(candidates, key=_eval_reward)
     model = np.load(best / "model.npz")
     plots.q_values_heatmap(model["q_table"], None, out / "F11_heatmap_qvalues.png")
 

--- a/scripts/make_figures.py
+++ b/scripts/make_figures.py
@@ -1,0 +1,313 @@
+"""Generate the report figures (F1-F12) from campaign data in results/.
+
+Reads ONLY results/raw + results/aggregated (+ r_star.json); never re-runs
+experiments. Any figure can therefore be regenerated at will:
+
+    python scripts/make_figures.py            # everything available
+    python scripts/make_figures.py --figures f1,f5
+
+Missing experiment blocks are skipped with a notice (so the script works on
+partial campaigns).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from src.evaluation.metrics import mean_ci95  # noqa: E402
+from src.visualization import plots  # noqa: E402
+
+ALGO_LABELS = {
+    "brute_force": "BruteForce",
+    "q_learning": "Q-Learning",
+    "sarsa": "SARSA",
+    "expected_sarsa": "Expected SARSA",
+    "double_q_learning": "Double Q-Learning",
+    "monte_carlo": "Monte Carlo",
+    "dqn": "DQN",
+}
+
+
+def _runs_frame(results: Path, exp_id: str) -> pd.DataFrame | None:
+    path = results / "aggregated" / f"{exp_id}__runs.csv"
+    if not path.exists():
+        print(f"  [skip] {path} missing")
+        return None
+    return pd.read_csv(path)
+
+
+def _run_dirs(results: Path, exp_id: str) -> list[Path]:
+    exp = results / "raw" / exp_id
+    return sorted(d for d in exp.glob("*") if (d / "summary.json").exists()) if exp.exists() else []
+
+
+def _train_series(run_dir: Path, column: str) -> list[float]:
+    with open(run_dir / "train_episodes.csv") as handle:
+        return [float(row[column]) for row in csv.DictReader(handle)]
+
+
+def _probe_series(run_dir: Path) -> tuple[list[int], list[float], list[float]]:
+    episodes: list[int] = []
+    rewards: list[float] = []
+    max_qs: list[float] = []
+    with open(run_dir / "probes.csv") as handle:
+        for row in csv.DictReader(handle):
+            episodes.append(int(row["episode"]))
+            rewards.append(float(row["probe_mean_reward"]))
+            max_qs.append(float(row.get("probe_max_q", "nan")))
+    return episodes, rewards, max_qs
+
+
+def _algo_of(run_dir: Path) -> str:
+    return run_dir.name.split("__")[0]
+
+
+def _grouped_train_series(
+    results: Path, exp_id: str, column: str, algos: list[str] | None = None
+) -> dict[str, list[list[float]]]:
+    series: dict[str, list[list[float]]] = {}
+    for run_dir in _run_dirs(results, exp_id):
+        algo = _algo_of(run_dir)
+        if algos and algo not in algos:
+            continue
+        series.setdefault(ALGO_LABELS.get(algo, algo), []).append(_train_series(run_dir, column))
+    return series
+
+
+def _r_star(results: Path) -> float | None:
+    path = results / "r_star.json"
+    if not path.exists():
+        return None
+    with open(path) as handle:
+        return float(json.load(handle)["r_star_probe"])
+
+
+def fig_f1_f2(results: Path, out: Path) -> None:
+    series_r = _grouped_train_series(results, "e2", "reward")
+    if not series_r:
+        return
+    plots.learning_curves(series_r, out / "F1_courbes_apprentissage.png")
+    series_s = _grouped_train_series(results, "e2", "steps")
+    plots.learning_curves(
+        series_s,
+        out / "F2_courbes_steps.png",
+        ylabel="Pas par épisode",
+        title="Nombre de pas par épisode",
+    )
+
+
+def fig_f3_f4(results: Path, out: Path) -> None:
+    frame_e2 = _runs_frame(results, "e2")
+    if frame_e2 is None:
+        return
+    groups = {
+        ALGO_LABELS.get(algo, algo): subset["eval_mean_reward"].tolist()
+        for algo, subset in frame_e2.groupby("algorithm")
+    }
+    plots.reward_boxplots(groups, out / "F3_boxplots_rewards.png")
+
+    frames = [frame_e2]
+    frame_e0 = _runs_frame(results, "e0")
+    if frame_e0 is not None:
+        frames.append(frame_e0[frame_e0["algorithm"] == "brute_force"])
+    merged = pd.concat(frames)
+    means: dict[str, float] = {}
+    cis: dict[str, float] = {}
+    for algo, subset in merged.groupby("algorithm"):
+        values = subset["eval_mean_steps"].tolist()
+        label = ALGO_LABELS.get(str(algo), str(algo))
+        means[label] = float(np.mean(values))
+        low, high = mean_ci95(values)
+        cis[label] = (high - low) / 2
+    plots.steps_barplot(means, cis, out / "F4_barplot_steps.png", log_scale=True)
+
+
+def fig_f5_f6(results: Path, out: Path) -> None:
+    frame = _runs_frame(results, "e1a")
+    if frame is None:
+        return
+    plots.grid_search_heatmap(frame, out / "F5_heatmap_grid.png")
+    plots.grid_search_heatmap(
+        frame,
+        out / "F5b_heatmap_convergence.png",
+        value_column="episodes_to_threshold",
+        title="Grid search Q-Learning : épisodes jusqu'au seuil",
+    )
+    frame_all = frame.assign(algorithm="q_learning")
+    frame_e1b = _runs_frame(results, "e1b")
+    if frame_e1b is not None:
+        frame_all = pd.concat([frame_all, frame_e1b])
+    plots.sensitivity_curves(
+        frame_all[frame_all["gamma"] == 0.99],
+        "alpha",
+        out / "F6a_sensibilite_alpha.png",
+        title="Sensibilité à α (γ=0.99)",
+    )
+    plots.sensitivity_curves(
+        frame_all[frame_all["alpha"] == 0.15],
+        "gamma",
+        out / "F6b_sensibilite_gamma.png",
+        title="Sensibilité à γ (α=0.15)",
+    )
+
+
+def _probe_group(
+    results: Path, exp_id: str, label_fn: object
+) -> dict[str, tuple[list[int], list[list[float]]]]:
+    grouped: dict[str, tuple[list[int], list[list[float]]]] = {}
+    for run_dir in _run_dirs(results, exp_id):
+        with open(run_dir / "config.json") as handle:
+            config = json.load(handle)["config"]
+        label = label_fn(config)  # type: ignore[operator]
+        episodes, rewards, _ = _probe_series(run_dir)
+        if label not in grouped:
+            grouped[label] = (episodes, [])
+        if len(rewards) == len(grouped[label][0]):
+            grouped[label][1].append(rewards)
+    return grouped
+
+
+def fig_f7_f8(results: Path, out: Path) -> None:
+    threshold = _r_star(results)
+    threshold_09 = 0.9 * threshold if threshold is not None else None
+
+    def explo_label(config: dict) -> str:
+        if config["exploration"] == "epsilon_greedy":
+            return f"ε-greedy ({config['decay_type']})"
+        return str(config["exploration"])
+
+    grouped = _probe_group(results, "e3", explo_label)
+    if grouped:
+        plots.probe_curves(
+            grouped,
+            out / "F7_exploration.png",
+            title="Stratégies d'exploration (sondes greedy)",
+            threshold=threshold_09,
+        )
+    grouped = _probe_group(results, "e4", lambda c: str(c["reward_shaping"]))
+    if grouped:
+        plots.probe_curves(
+            grouped,
+            out / "F8_reward_shaping.png",
+            title="Reward shaping — récompense NATIVE (sondes greedy)",
+            threshold=threshold_09,
+        )
+
+
+def fig_f9(results: Path, out: Path) -> None:
+    """Sample efficiency: greedy probe reward vs cumulative env steps."""
+    series: dict[str, tuple[list[float], list[list[float]]]] = {}
+    for run_dir in _run_dirs(results, "e2"):
+        algo = _algo_of(run_dir)
+        if algo not in ("q_learning", "dqn"):
+            continue
+        episodes, rewards, _ = _probe_series(run_dir)
+        steps = _train_series(run_dir, "steps")
+        cum = np.cumsum(steps)
+        x = [float(cum[min(e, len(cum)) - 1]) for e in episodes]
+        label = ALGO_LABELS[algo]
+        if label not in series:
+            series[label] = (x, [])
+        if len(rewards) == len(series[label][0]):
+            series[label][1].append(rewards)
+    if series:
+        plots.sample_efficiency_plot(series, out / "F9_efficacite_echantillon.png")
+
+
+def fig_f10(results: Path, out: Path) -> None:
+    """Overestimation: probe max-Q trajectories QL vs Double QL vs realized."""
+    grouped: dict[str, tuple[list[int], list[list[float]]]] = {}
+    realized: dict[str, tuple[list[int], list[list[float]]]] = {}
+    for run_dir in _run_dirs(results, "e2"):
+        algo = _algo_of(run_dir)
+        if algo not in ("q_learning", "double_q_learning"):
+            continue
+        episodes, rewards, max_qs = _probe_series(run_dir)
+        label = ALGO_LABELS[algo]
+        grouped.setdefault(label + " (max Q)", (episodes, []))[1].append(max_qs)
+        realized.setdefault(label + " (retour réalisé)", (episodes, []))[1].append(rewards)
+    if grouped:
+        plots.probe_curves(
+            {**grouped, **realized},
+            out / "F10_surestimation.png",
+            ylabel="Valeur",
+            title="Biais de surestimation : max Q estimé vs retour réalisé",
+        )
+
+
+def fig_f11(results: Path, out: Path) -> None:
+    """Q-value heatmaps + GIF from the best e2 Q-Learning run."""
+    candidates = [d for d in _run_dirs(results, "e2") if _algo_of(d) == "q_learning"]
+    if not candidates:
+        return
+    best = max(
+        candidates,
+        key=lambda d: json.load(open(d / "summary.json"))["eval_mean_reward"],
+    )
+    model = np.load(best / "model.npz")
+    plots.q_values_heatmap(model["q_table"], None, out / "F11_heatmap_qvalues.png")
+
+    from src.agents import create_agent
+    from src.config import Config
+    from src.environments import create_env
+    from src.visualization.episode_replay import save_episode_gif
+
+    config = Config(algorithm="q_learning")
+    agent = create_agent(config, create_env(config))
+    agent.load(best / "model.npz")
+    save_episode_gif(agent, out / "F11b_episode.gif", seed=10042)
+
+
+def fig_f12(results: Path, out: Path) -> None:
+    grouped = _probe_group(results, "e6", lambda c: ALGO_LABELS[str(c["algorithm"])])
+    if grouped:
+        plots.probe_curves(
+            grouped,
+            out / "F12_multi_passagers.png",
+            title="Multi-passagers (14 400 états) : convergence",
+            log_x=True,
+        )
+
+
+FIGURES = {
+    "f1": fig_f1_f2,
+    "f3": fig_f3_f4,
+    "f5": fig_f5_f6,
+    "f7": fig_f7_f8,
+    "f9": fig_f9,
+    "f10": fig_f10,
+    "f11": fig_f11,
+    "f12": fig_f12,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results", default="results")
+    parser.add_argument("--out", default="results/figures")
+    parser.add_argument("--figures", default=",".join(FIGURES))
+    args = parser.parse_args()
+
+    results = Path(args.results)
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    for name in (f.strip() for f in args.figures.split(",") if f.strip()):
+        if name not in FIGURES:
+            parser.error(f"unknown figure group: {name} (choose from {sorted(FIGURES)})")
+        print(f"generating {name}...")
+        FIGURES[name](results, out)
+    print(f"figures written to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_campaign.py
+++ b/scripts/run_campaign.py
@@ -1,0 +1,295 @@
+"""Benchmark campaign driver: experiment blocks E0-E7 (docs/PROTOCOLE.md).
+
+Blocks E0-E6 run in parallel across processes (their metrics are unaffected
+by parallelism); E7 re-runs the head-to-head configurations SEQUENTIALLY and
+is the only legitimate source of wall-clock timing and memory columns in the
+report. Runs are idempotent — re-launching the script resumes after a crash.
+
+Usage:
+    python scripts/run_campaign.py --blocks e0,e1a,e2 --workers 6
+    python scripts/run_campaign.py            # everything, ~4h30-5h30
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.benchmarking.benchmarker import (
+    EVAL_BASE_SEED,
+    RunSpec,
+    aggregate_runs,
+    run_block,
+    write_optimized_yaml,
+)
+from src.config import Config
+
+N_SEEDS = 10
+SEEDS = list(range(42, 42 + N_SEEDS))
+TABULAR_EPISODES = 15_000
+DQN_EPISODES = 5_000
+MULTI_EPISODES = 150_000
+
+# Reference tabular configuration (protocol §0): probes every 100 episodes,
+# epsilon reaching its floor at 60% of the horizon, early stopping disabled.
+REFERENCE = Config(
+    algorithm="q_learning",
+    alpha=0.15,
+    gamma=0.99,
+    epsilon=1.0,
+    epsilon_min=0.01,
+    decay_type="exp",
+    decay_frac=0.6,
+    n_train_episodes=TABULAR_EPISODES,
+    n_test_episodes=100,
+    eval_interval=100,
+    n_probe_episodes=30,
+    early_stopping=False,
+)
+
+TABULAR_ALGOS = (
+    "q_learning",
+    "sarsa",
+    "expected_sarsa",
+    "double_q_learning",
+    "monte_carlo",
+)
+
+DQN_REFERENCE = dataclasses.replace(
+    REFERENCE,
+    algorithm="dqn",
+    n_train_episodes=DQN_EPISODES,
+    lr=1e-3,
+    hidden_size=128,
+    device="auto",
+)
+
+
+def _ref(**overrides: object) -> Config:
+    return dataclasses.replace(REFERENCE, **overrides)  # type: ignore[arg-type]
+
+
+def specs_e0() -> list[RunSpec]:
+    """Brute-force baseline; the 2000-step variant removes the 200-step
+    truncation artifact behind the subject's ~350-step figure."""
+    capped = _ref(algorithm="brute_force", n_train_episodes=0, n_test_episodes=1000)
+    uncapped = dataclasses.replace(capped, max_steps_per_episode=2000)
+    return [RunSpec("e0", config, seed) for config in (capped, uncapped) for seed in SEEDS]
+
+
+def specs_e1a() -> list[RunSpec]:
+    """Q-Learning grid: 5 alpha x 4 gamma x 10 seeds = 200 runs (H1, H3, F5)."""
+    return [
+        RunSpec("e1a", _ref(alpha=alpha, gamma=gamma), seed)
+        for alpha in (0.05, 0.1, 0.15, 0.2, 0.3)
+        for gamma in (0.9, 0.95, 0.99, 0.999)
+        for seed in SEEDS
+    ]
+
+
+def specs_e1b() -> list[RunSpec]:
+    """Cross-algorithm grid: 4 algos x 3 alpha x 3 gamma x 10 seeds (H3)."""
+    return [
+        RunSpec("e1b", _ref(algorithm=algorithm, alpha=alpha, gamma=gamma), seed)
+        for algorithm in ("sarsa", "expected_sarsa", "double_q_learning", "monte_carlo")
+        for alpha in (0.05, 0.15, 0.3)
+        for gamma in (0.9, 0.99, 0.999)
+        for seed in SEEDS
+    ]
+
+
+def specs_e2() -> list[RunSpec]:
+    """Head-to-head at the reference configuration: 6 tabular + DQN (T1, H2/6/7/8)."""
+    specs = [
+        RunSpec("e2", _ref(algorithm=algorithm), seed)
+        for algorithm in TABULAR_ALGOS
+        for seed in SEEDS
+    ]
+    specs += [RunSpec("e2", DQN_REFERENCE, seed) for seed in SEEDS]
+    return specs
+
+
+def specs_e3() -> list[RunSpec]:
+    """Exploration strategies on Q-Learning (H4)."""
+    variants = [
+        _ref(),  # epsilon-greedy, exponential decay (reference)
+        _ref(decay_type="linear"),
+        _ref(exploration="boltzmann"),
+        _ref(exploration="ucb"),
+    ]
+    return [RunSpec("e3", config, seed) for config in variants for seed in SEEDS]
+
+
+def specs_e4() -> list[RunSpec]:
+    """Reward shaping variants on Q-Learning (H5)."""
+    return [
+        RunSpec("e4", _ref(reward_shaping=shaping), seed)
+        for shaping in ("none", "potential", "naive_distance", "step_penalty")
+        for seed in SEEDS
+    ]
+
+
+def specs_e5() -> list[RunSpec]:
+    """DQN sensitivity: lr x hidden, 5 seeds (exploratory)."""
+    return [
+        RunSpec(
+            "e5",
+            dataclasses.replace(DQN_REFERENCE, lr=lr, hidden_size=hidden),
+            seed,
+        )
+        for lr in (1e-4, 5e-4, 1e-3)
+        for hidden in (64, 128)
+        # protocol cut order applied: E5 is exploratory, 3 seeds (~12 min/run)
+        for seed in SEEDS[:3]
+    ]
+
+
+def specs_e6() -> list[RunSpec]:
+    """Multi-passenger scaling: QL and SARSA on the 14,400-state env (H9)."""
+    return [
+        RunSpec(
+            "e6",
+            _ref(
+                algorithm=algorithm,
+                env="multi",
+                n_train_episodes=MULTI_EPISODES,
+                eval_interval=1000,
+                max_steps_per_episode=500,
+            ),
+            seed,
+        )
+        for algorithm in ("q_learning", "sarsa")
+        for seed in SEEDS
+    ]
+
+
+def specs_e7() -> list[RunSpec]:
+    """Timing block (STRICTLY SEQUENTIAL): tabular x 10 seeds, DQN cuda/cpu x 3."""
+    specs = [
+        RunSpec("e7", _ref(algorithm=algorithm), seed)
+        for algorithm in ("brute_force", *TABULAR_ALGOS)
+        for seed in SEEDS
+    ]
+    for device in ("cuda", "cpu"):
+        config = dataclasses.replace(DQN_REFERENCE, device=device)
+        # sequential DQN timing runs are expensive: 2 seeds per device
+        # (time varies little across seeds; documented in the report)
+        specs += [RunSpec("e7", config, seed) for seed in SEEDS[:2]]
+    return specs
+
+
+BLOCKS: dict[str, tuple[object, bool]] = {
+    # name: (spec factory, sequential)
+    "e0": (specs_e0, False),
+    "e1a": (specs_e1a, False),
+    "e1b": (specs_e1b, False),
+    "e2": (specs_e2, False),
+    "e3": (specs_e3, False),
+    "e4": (specs_e4, False),
+    "e5": (specs_e5, False),
+    "e6": (specs_e6, False),
+    "e7": (specs_e7, True),
+}
+
+
+def compute_r_star(results_root: Path) -> float:
+    """Compute (or reload) the optimal-policy reference reward R*."""
+    r_star_path = results_root / "r_star.json"
+    if r_star_path.exists():
+        with open(r_star_path) as handle:
+            return float(json.load(handle)["r_star"])
+    from src.benchmarking.value_iteration import optimal_reference_reward
+    from src.environments import create_env
+    from src.utils.seeding import eval_seeds, probe_seeds
+
+    env = create_env(Config())
+    r_star_eval = optimal_reference_reward(env, eval_seeds(EVAL_BASE_SEED, 100))
+    r_star_probe = optimal_reference_reward(env, probe_seeds(EVAL_BASE_SEED, 30))
+    results_root.mkdir(parents=True, exist_ok=True)
+    with open(r_star_path, "w") as handle:
+        json.dump(
+            {"r_star": r_star_eval, "r_star_probe": r_star_probe, "gamma": 0.99},
+            handle,
+            indent=2,
+        )
+    print(f"R* (eval set) = {r_star_eval:.3f} | R* (probe set) = {r_star_probe:.3f}")
+    return r_star_eval
+
+
+def maybe_write_optimized(results_root: Path) -> None:
+    """Promote the E1a grid winner to configs/optimized.yaml."""
+    frame = aggregate_runs(results_root, "e1a")
+    ranking = (
+        frame.groupby(["alpha", "gamma"])["eval_mean_reward"]
+        .agg(["mean", "count"])
+        .sort_values("mean", ascending=False)
+        .reset_index()
+    )
+    best = ranking.iloc[0]
+    best_config = _ref(alpha=float(best["alpha"]), gamma=float(best["gamma"]))
+    write_optimized_yaml(
+        best_config,
+        Path("configs/optimized.yaml"),
+        note=(
+            f"Grid-search winner of E1a: alpha={best['alpha']}, gamma={best['gamma']} "
+            f"(mean test reward {best['mean']:.3f} over {int(best['count'])} seeds)."
+        ),
+    )
+    print(
+        f"optimized.yaml <- alpha={best['alpha']}, gamma={best['gamma']} "
+        f"(reward {best['mean']:.3f})"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--blocks", default=",".join(BLOCKS), help="comma-separated block ids")
+    parser.add_argument("--workers", type=int, default=6)
+    parser.add_argument("--results", default="results")
+    parser.add_argument("--dry-run", action="store_true", help="print run counts and exit")
+    args = parser.parse_args()
+
+    results_root = Path(args.results)
+    selected = [block.strip() for block in args.blocks.split(",") if block.strip()]
+    unknown = set(selected) - set(BLOCKS)
+    if unknown:
+        parser.error(f"unknown blocks: {sorted(unknown)}")
+
+    all_specs = {name: BLOCKS[name][0]() for name in selected}  # type: ignore[operator]
+    total = sum(len(specs) for specs in all_specs.values())
+    for name, specs in all_specs.items():
+        sequential = BLOCKS[name][1]
+        print(f"  {name}: {len(specs)} runs{' (sequential)' if sequential else ''}")
+    print(f"total: {total} runs")
+    if args.dry_run:
+        return 0
+
+    r_star = compute_r_star(results_root)
+    campaign_start = time.monotonic()
+    for name in selected:
+        specs = all_specs[name]
+        sequential = BLOCKS[name][1]
+        block_start = time.monotonic()
+        print(f"\n=== block {name}: {len(specs)} runs ===")
+        run_block(
+            specs,
+            results_root=results_root,
+            n_workers=args.workers,
+            sequential=sequential,
+        )
+        aggregate_runs(results_root, name, r_star=r_star)
+        print(f"=== block {name} done in {(time.monotonic() - block_start) / 60:.1f} min ===")
+        if name == "e1a":
+            maybe_write_optimized(results_root)
+    print(f"\ncampaign finished in {(time.monotonic() - campaign_start) / 60:.1f} min")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/benchmarking/benchmarker.py
+++ b/src/benchmarking/benchmarker.py
@@ -118,6 +118,9 @@ def run_single(spec: RunSpec, results_root: str | Path = "results") -> dict[str,
     evaluator = Evaluator(env, seeds=eval_seeds(EVAL_BASE_SEED, config.n_test_episodes))
     results = evaluator.evaluate(agent, config.n_test_episodes)
 
+    model_name = "model.pt" if config.algorithm == "dqn" else "model.npz"
+    agent.save(run_dir / model_name)
+
     _write_config(run_dir, spec, config)
     _write_train_csv(run_dir, history)
     _write_probes_csv(run_dir, history)
@@ -164,11 +167,12 @@ def _write_train_csv(run_dir: Path, history: TrainingHistory) -> None:
 def _write_probes_csv(run_dir: Path, history: TrainingHistory) -> None:
     with open(run_dir / "probes.csv", "w", newline="") as handle:
         writer = csv.writer(handle)
-        writer.writerow(["episode", "probe_mean_reward", "probe_mean_steps"])
-        for episode, reward, steps in zip(
-            history.probe_episodes, history.probe_rewards, history.probe_steps, strict=True
+        writer.writerow(["episode", "probe_mean_reward", "probe_mean_steps", "probe_max_q"])
+        max_qs = history.probe_max_q or [float("nan")] * len(history.probe_episodes)
+        for episode, reward, steps, max_q in zip(
+            history.probe_episodes, history.probe_rewards, history.probe_steps, max_qs, strict=True
         ):
-            writer.writerow([episode, reward, steps])
+            writer.writerow([episode, reward, steps, max_q])
 
 
 def _write_eval_csv(run_dir: Path, results: Any, eval_base_seed: int) -> None:
@@ -223,6 +227,7 @@ def _build_summary(
         # probes (raw series kept for threshold computation at aggregation)
         "probe_episodes": history.probe_episodes,
         "probe_rewards": history.probe_rewards,
+        "probe_max_q": history.probe_max_q,
         # evaluation (fixed seed set)
         "eval_mean_reward": results.mean_reward,
         "eval_std_reward": results.std_reward,

--- a/src/benchmarking/benchmarker.py
+++ b/src/benchmarking/benchmarker.py
@@ -1,0 +1,378 @@
+"""Experiment runner: reproducible, idempotent, parallelizable benchmark runs.
+
+Each run is identified by ``(exp_id, config_hash, seed)`` and materialized as
+a directory under ``results/raw/<exp_id>/``:
+
+    <algo>__<confighash8>__s<seed>__<timestamp>/
+        config.json          resolved config + code version + library versions
+        train_episodes.csv   one row per training episode
+        probes.csv           one row per greedy probe checkpoint
+        eval_episodes.csv    one row per (fixed-seed) evaluation episode
+        summary.json         aggregates consumed by results/aggregated/
+
+Runs are idempotent: an existing completed run directory for the same
+identity is reused (crash-resume for free). Parallel execution across
+processes is safe because runs never share files; time measurements intended
+for the report must come from sequential blocks only (protocol E7).
+"""
+
+from __future__ import annotations
+
+import csv
+import dataclasses
+import datetime
+import json
+import platform
+import sys
+from dataclasses import dataclass
+from multiprocessing import get_context
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from src.agents import create_agent
+from src.benchmarking.reward_shaping import create_reward_shaper
+from src.config import Config
+from src.environments import create_env
+from src.evaluation.evaluator import Evaluator
+from src.training.trainer import Trainer, TrainingHistory
+from src.utils.seeding import eval_seeds
+
+# All runs are EVALUATED on the same fixed episode set, regardless of their
+# training seed — the precondition for paired, fair comparisons.
+EVAL_BASE_SEED = 42
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    """One benchmark run: a configuration trained with one seed."""
+
+    exp_id: str
+    config: Config
+    seed: int  # training seed (env + agent streams)
+
+    @property
+    def run_id(self) -> str:
+        return f"{self.config.algorithm}__{self.config.config_hash()}__s{self.seed}"
+
+
+def _library_versions() -> dict[str, str]:
+    import gymnasium
+    import scipy
+
+    versions = {
+        "python": platform.python_version(),
+        "numpy": np.__version__,
+        "gymnasium": gymnasium.__version__,
+        "scipy": scipy.__version__,
+        "platform": platform.platform(),
+    }
+    if "torch" in sys.modules:
+        versions["torch"] = sys.modules["torch"].__version__
+    return versions
+
+
+def find_completed_run(results_root: Path, spec: RunSpec) -> Path | None:
+    """Return an existing completed run directory for this identity, if any."""
+    exp_dir = results_root / "raw" / spec.exp_id
+    if not exp_dir.exists():
+        return None
+    for candidate in sorted(exp_dir.glob(f"{spec.run_id}__*")):
+        if (candidate / "summary.json").exists():
+            return candidate
+    return None
+
+
+def run_single(spec: RunSpec, results_root: str | Path = "results") -> dict[str, Any]:
+    """Execute one benchmark run (train → probe → evaluate → persist).
+
+    Args:
+        spec: Run specification; ``spec.seed`` overrides the config seed for
+            training streams. Evaluation always uses the fixed
+            ``EVAL_BASE_SEED`` episode set.
+        results_root: Base results directory.
+
+    Returns:
+        The summary dictionary (also written to ``summary.json``).
+    """
+    results_root = Path(results_root)
+    existing = find_completed_run(results_root, spec)
+    if existing is not None:
+        with open(existing / "summary.json") as handle:
+            return dict(json.load(handle))
+
+    config = dataclasses.replace(spec.config, seed=spec.seed)
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = results_root / "raw" / spec.exp_id / f"{spec.run_id}__{timestamp}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    reward_fn = create_reward_shaper(config.reward_shaping, config.gamma)
+    env = create_env(config, reward_fn=reward_fn)
+    probe_env = create_env(config) if config.eval_interval > 0 else None  # native rewards
+    agent = create_agent(config, env, n_episodes=config.n_train_episodes)
+
+    trainer = Trainer(agent, env, config, probe_env=probe_env)
+    history = trainer.train(config.n_train_episodes)
+
+    evaluator = Evaluator(env, seeds=eval_seeds(EVAL_BASE_SEED, config.n_test_episodes))
+    results = evaluator.evaluate(agent, config.n_test_episodes)
+
+    _write_config(run_dir, spec, config)
+    _write_train_csv(run_dir, history)
+    _write_probes_csv(run_dir, history)
+    _write_eval_csv(run_dir, results, EVAL_BASE_SEED)
+    summary = _build_summary(spec, config, history, results, agent.memory_bytes())
+    with open(run_dir / "summary.json", "w") as handle:
+        json.dump(summary, handle, indent=2)
+    return summary
+
+
+def _write_config(run_dir: Path, spec: RunSpec, config: Config) -> None:
+    payload = {
+        "exp_id": spec.exp_id,
+        "run_id": spec.run_id,
+        "config": config.to_dict(),
+        "config_hash": config.config_hash(),
+        "eval_base_seed": EVAL_BASE_SEED,
+        "versions": _library_versions(),
+    }
+    with open(run_dir / "config.json", "w") as handle:
+        json.dump(payload, handle, indent=2)
+
+
+def _write_train_csv(run_dir: Path, history: TrainingHistory) -> None:
+    with open(run_dir / "train_episodes.csv", "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            ["episode", "reward", "shaped_reward", "steps", "epsilon", "illegal", "terminated"]
+        )
+        for i in range(len(history.rewards)):
+            writer.writerow(
+                [
+                    i,
+                    history.rewards[i],
+                    history.shaped_rewards[i],
+                    history.steps[i],
+                    f"{history.epsilons[i]:.6f}",
+                    history.illegal_actions[i],
+                    int(history.terminated[i]),
+                ]
+            )
+
+
+def _write_probes_csv(run_dir: Path, history: TrainingHistory) -> None:
+    with open(run_dir / "probes.csv", "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["episode", "probe_mean_reward", "probe_mean_steps"])
+        for episode, reward, steps in zip(
+            history.probe_episodes, history.probe_rewards, history.probe_steps, strict=True
+        ):
+            writer.writerow([episode, reward, steps])
+
+
+def _write_eval_csv(run_dir: Path, results: Any, eval_base_seed: int) -> None:
+    seeds = eval_seeds(eval_base_seed, results.n_episodes)
+    with open(run_dir / "eval_episodes.csv", "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            ["episode", "eval_seed", "reward", "steps", "success", "illegal", "seconds"]
+        )
+        for i in range(results.n_episodes):
+            writer.writerow(
+                [
+                    i,
+                    seeds[i],
+                    results.rewards[i],
+                    results.steps[i],
+                    int(results.successes[i]),
+                    results.illegal_actions[i],
+                    f"{results.durations[i]:.6f}",
+                ]
+            )
+
+
+def _first_success_episode(history: TrainingHistory) -> int | None:
+    for i, terminated in enumerate(history.terminated):
+        if terminated:
+            return i
+    return None
+
+
+def _build_summary(
+    spec: RunSpec,
+    config: Config,
+    history: TrainingHistory,
+    results: Any,
+    memory_bytes: int,
+) -> dict[str, Any]:
+    last100 = history.rewards[-100:]
+    return {
+        "exp_id": spec.exp_id,
+        "run_id": spec.run_id,
+        "algorithm": config.algorithm,
+        "config_hash": config.config_hash(),
+        "seed": spec.seed,
+        # training
+        "n_train_episodes": len(history.rewards),
+        "train_wall_time_s": history.wall_time,
+        "stop_reason": history.stop_reason,
+        "first_success_episode": _first_success_episode(history),
+        "post_convergence_std": float(np.std(last100)) if last100 else None,
+        "cum_env_steps": int(np.sum(history.steps)),
+        # probes (raw series kept for threshold computation at aggregation)
+        "probe_episodes": history.probe_episodes,
+        "probe_rewards": history.probe_rewards,
+        # evaluation (fixed seed set)
+        "eval_mean_reward": results.mean_reward,
+        "eval_std_reward": results.std_reward,
+        "eval_median_reward": results.median_reward,
+        "eval_mean_steps": results.mean_steps,
+        "eval_median_steps": results.median_steps,
+        "eval_success_rate": results.success_rate,
+        "eval_mean_illegal": results.mean_illegal_actions,
+        "eval_mean_episode_seconds": results.mean_episode_seconds,
+        # resources
+        "memory_bytes": memory_bytes,
+        # hyperparameters (flattened for aggregation convenience)
+        "alpha": config.alpha,
+        "gamma": config.gamma,
+        "exploration": config.exploration,
+        "decay_type": config.decay_type,
+        "decay_frac": config.decay_frac,
+        "epsilon_decay": config.epsilon_decay,
+        "reward_shaping": config.reward_shaping,
+    }
+
+
+def _run_single_star(payload: tuple[RunSpec, str]) -> dict[str, Any]:
+    spec, results_root = payload
+    # Keep BLAS/torch from oversubscribing cores in parallel pools.
+    try:
+        import torch
+
+        torch.set_num_threads(1)
+    except ImportError:
+        pass
+    return run_single(spec, results_root)
+
+
+def run_block(
+    specs: list[RunSpec],
+    results_root: str | Path = "results",
+    n_workers: int = 6,
+    sequential: bool = False,
+    progress: bool = True,
+) -> list[dict[str, Any]]:
+    """Run a block of specs, in parallel (metrics) or sequentially (timing).
+
+    Args:
+        specs: Run specifications.
+        results_root: Base results directory.
+        n_workers: Pool size for the parallel path.
+        sequential: True for timing-sensitive blocks (protocol E7): no pool,
+            no thread capping, machine assumed otherwise idle.
+        progress: Print one line per completed run.
+
+    Returns:
+        List of run summaries, in completion order.
+    """
+    results_root = str(results_root)
+    summaries: list[dict[str, Any]] = []
+    if sequential:
+        for i, spec in enumerate(specs):
+            summaries.append(run_single(spec, results_root))
+            if progress:
+                print(f"[{i + 1}/{len(specs)}] {spec.exp_id}/{spec.run_id} done")
+        return summaries
+    payloads = [(spec, results_root) for spec in specs]
+    with get_context("spawn").Pool(n_workers) as pool:
+        for i, summary in enumerate(pool.imap_unordered(_run_single_star, payloads)):
+            summaries.append(summary)
+            if progress:
+                print(f"[{i + 1}/{len(specs)}] {summary['exp_id']}/{summary['run_id']} done")
+    return summaries
+
+
+# ------------------------------------------------------------------ aggregation
+
+
+def episodes_to_threshold(
+    probe_episodes: list[int],
+    probe_rewards: list[float],
+    threshold: float,
+    sustain: int = 3,
+) -> int | None:
+    """First probe episode from which the reward stays >= threshold.
+
+    The threshold must hold for ``sustain`` consecutive checkpoints; returns
+    None when never reached (censored run).
+    """
+    count = 0
+    start: int | None = None
+    for episode, reward in zip(probe_episodes, probe_rewards, strict=True):
+        if reward >= threshold:
+            if count == 0:
+                start = episode
+            count += 1
+            if count >= sustain:
+                return start
+        else:
+            count = 0
+            start = None
+    return None
+
+
+def aggregate_runs(
+    results_root: str | Path,
+    exp_id: str,
+    r_star: float | None = None,
+    threshold_fraction: float = 0.9,
+) -> Any:
+    """Collect all run summaries of an experiment into a DataFrame.
+
+    Args:
+        results_root: Base results directory.
+        exp_id: Experiment identifier (e.g. ``"e2"``).
+        r_star: Optimal reference reward; when given, adds an
+            ``episodes_to_threshold`` column (None = censored).
+        threshold_fraction: Fraction of R* defining convergence.
+
+    Returns:
+        pandas DataFrame, one row per run, written to
+        ``results/aggregated/<exp_id>__runs.csv``.
+    """
+    import pandas as pd
+
+    results_root = Path(results_root)
+    rows: list[dict[str, Any]] = []
+    for summary_path in sorted((results_root / "raw" / exp_id).glob("*/summary.json")):
+        with open(summary_path) as handle:
+            summary = json.load(handle)
+        if r_star is not None:
+            summary["episodes_to_threshold"] = episodes_to_threshold(
+                summary.get("probe_episodes", []),
+                summary.get("probe_rewards", []),
+                threshold_fraction * r_star,
+            )
+            summary["converged"] = summary["episodes_to_threshold"] is not None
+        summary.pop("probe_episodes", None)
+        summary.pop("probe_rewards", None)
+        rows.append(summary)
+    frame = pd.DataFrame(rows)
+    out_dir = results_root / "aggregated"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    frame.to_csv(out_dir / f"{exp_id}__runs.csv", index=False)
+    return frame
+
+
+def write_optimized_yaml(config: Config, path: str | Path, note: str) -> None:
+    """Persist a tuned configuration as ``configs/optimized.yaml``."""
+    import yaml
+
+    payload = config.to_dict()
+    payload["mode"] = "time_limited"
+    header = "# Optimized configuration (time-limited mode).\n" f"# {note}\n"
+    with open(path, "w") as handle:
+        handle.write(header)
+        yaml.safe_dump(payload, handle, sort_keys=False)

--- a/src/benchmarking/reward_shaping.py
+++ b/src/benchmarking/reward_shaping.py
@@ -1,0 +1,100 @@
+"""Reward-shaping functions for the Taxi environment.
+
+Three variants are compared in the H5 experiment (block E4):
+
+- ``potential``: potential-based shaping F = γ·Φ(s') − Φ(s) with
+  Φ(s) = −(Manhattan distance to the current objective). Ng, Harada &
+  Russell (1999) prove this family preserves the optimal policy.
+- ``naive_distance``: a plain distance-improvement bonus, NOT potential-based
+  — expected to distort the optimal policy (negative control).
+- ``step_penalty``: doubles the per-step cost (reward − 1 on moves).
+
+All shapers receive and return floats via the wrapper hook signature
+``(state, action, raw_reward, next_state) -> float``; the native reward is
+always preserved in ``info["raw_reward"]`` by the wrapper.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from src.environments.taxi_wrapper import TAXI_LOCATIONS
+
+RewardFn = Callable[[int, int, float, int], float]
+
+_IN_TAXI = 4
+
+
+def _decode(state: int) -> tuple[int, int, int, int]:
+    """Decode a Taxi-v3 state integer without an env instance."""
+    destination = state % 4
+    state //= 4
+    passenger = state % 5
+    state //= 5
+    col = state % 5
+    row = state // 5
+    return row, col, passenger, destination
+
+
+def _objective_distance(state: int) -> int:
+    """Manhattan distance from the taxi to its current objective.
+
+    Objective = passenger location while not picked up, destination after.
+    """
+    row, col, passenger, destination = _decode(state)
+    target = TAXI_LOCATIONS[destination] if passenger == _IN_TAXI else TAXI_LOCATIONS[passenger]
+    return abs(row - target[0]) + abs(col - target[1])
+
+
+def potential(state: int) -> float:
+    """Φ(s) = −distance to the current objective (higher is better)."""
+    return -float(_objective_distance(state))
+
+
+def make_potential_shaper(gamma: float) -> RewardFn:
+    """Potential-based shaping (optimal-policy preserving, Ng et al. 1999)."""
+
+    def shaper(state: int, action: int, raw_reward: float, next_state: int) -> float:
+        return raw_reward + gamma * potential(next_state) - potential(state)
+
+    return shaper
+
+
+def make_naive_distance_shaper(bonus: float = 0.5) -> RewardFn:
+    """Non-potential distance bonus (negative control for H5).
+
+    Adds ``+bonus`` whenever the taxi gets closer to its objective. Because
+    the bonus is not a potential difference, cycles can accumulate reward and
+    the optimal policy is not guaranteed to be preserved.
+    """
+
+    def shaper(state: int, action: int, raw_reward: float, next_state: int) -> float:
+        if _objective_distance(next_state) < _objective_distance(state):
+            return raw_reward + bonus
+        return raw_reward
+
+    return shaper
+
+
+def make_step_penalty_shaper(extra_penalty: float = 1.0) -> RewardFn:
+    """Extra per-step penalty on movement steps (rewards −1 become −2)."""
+
+    def shaper(state: int, action: int, raw_reward: float, next_state: int) -> float:
+        if raw_reward == -1.0:
+            return raw_reward - extra_penalty
+        return raw_reward
+
+    return shaper
+
+
+def create_reward_shaper(name: str, gamma: float) -> RewardFn | None:
+    """Build the shaper named by ``Config.reward_shaping`` (None = native)."""
+    if name == "none":
+        return None
+    if name == "potential":
+        return make_potential_shaper(gamma)
+    if name == "naive_distance":
+        return make_naive_distance_shaper()
+    if name == "step_penalty":
+        return make_step_penalty_shaper()
+    raise ValueError(f"unknown reward shaping: {name!r}")

--- a/src/benchmarking/stats.py
+++ b/src/benchmarking/stats.py
@@ -1,0 +1,187 @@
+"""Statistical methodology for benchmark comparisons (protocol §5).
+
+Unit of analysis: the *run* (one seed), never individual episodes —
+comparing episode-level samples across configurations would be
+pseudo-replication. Normality is screened with Shapiro-Wilk (low power at
+n=10, hence both parametric and non-parametric results are reported when
+they disagree); Welch's t-test is used for normal-looking samples,
+Mann-Whitney U otherwise; families of hypotheses are corrected with
+Holm-Bonferroni; effect sizes are Hedges g (bias-corrected Cohen's d) and
+Cliff's delta.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from scipy import stats as sps
+
+from src.evaluation.metrics import mean_ci95
+
+
+def hedges_g(a: list[float], b: list[float]) -> float:
+    """Bias-corrected standardized mean difference (Hedges g).
+
+    Positive values mean ``a`` is larger than ``b``.
+    """
+    n_a, n_b = len(a), len(b)
+    if n_a < 2 or n_b < 2:
+        return float("nan")
+    var_a = float(np.var(a, ddof=1))
+    var_b = float(np.var(b, ddof=1))
+    pooled = np.sqrt(((n_a - 1) * var_a + (n_b - 1) * var_b) / (n_a + n_b - 2))
+    if pooled == 0:
+        return 0.0
+    d = (float(np.mean(a)) - float(np.mean(b))) / pooled
+    correction = 1.0 - 3.0 / (4.0 * (n_a + n_b) - 9.0)
+    return float(d * correction)
+
+
+def cliffs_delta(a: list[float], b: list[float]) -> float:
+    """Cliff's delta in [-1, 1]: P(a > b) − P(a < b)."""
+    if not a or not b:
+        return float("nan")
+    a_arr = np.asarray(a)[:, None]
+    b_arr = np.asarray(b)[None, :]
+    greater = float(np.sum(a_arr > b_arr))
+    lesser = float(np.sum(a_arr < b_arr))
+    return (greater - lesser) / (len(a) * len(b))
+
+
+def effect_size_label(g: float) -> str:
+    """Cohen's interpretation bands for |g|."""
+    magnitude = abs(g)
+    if magnitude < 0.2:
+        return "négligeable"
+    if magnitude < 0.5:
+        return "faible"
+    if magnitude < 0.8:
+        return "moyen"
+    return "fort"
+
+
+def holm_correction(p_values: list[float]) -> list[float]:
+    """Holm-Bonferroni step-down adjusted p-values (monotone, capped at 1)."""
+    m = len(p_values)
+    order = np.argsort(p_values)
+    adjusted = [0.0] * m
+    running_max = 0.0
+    for rank, index in enumerate(order):
+        value = min(1.0, (m - rank) * p_values[index])
+        running_max = max(running_max, value)
+        adjusted[index] = running_max
+    return adjusted
+
+
+@dataclass
+class ComparisonResult:
+    """One two-group comparison, ready for the report's T4 table."""
+
+    label_a: str
+    label_b: str
+    metric: str
+    mean_a: float
+    std_a: float
+    ci_a: tuple[float, float]
+    n_a: int
+    mean_b: float
+    std_b: float
+    ci_b: tuple[float, float]
+    n_b: int
+    normal_a: bool
+    normal_b: bool
+    test_name: str  # "welch" | "mann-whitney"
+    statistic: float
+    p_value: float
+    p_holm: float | None
+    hedges_g: float
+    cliffs_delta: float
+    secondary_test_name: str | None = None
+    secondary_p_value: float | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def significant(self, alpha: float = 0.05) -> bool:
+        return (self.p_holm if self.p_holm is not None else self.p_value) < alpha
+
+    def format_fr(self) -> str:
+        """Protocol §5.6 French report format."""
+        holm_text = f", p_Holm={self.p_holm:.4f}" if self.p_holm is not None else ""
+        return (
+            f"{self.label_a} : {self.mean_a:.2f} ± {self.std_a:.2f} "
+            f"(IC 95 % [{self.ci_a[0]:.2f} ; {self.ci_a[1]:.2f}], n={self.n_a}) vs "
+            f"{self.label_b} : {self.mean_b:.2f} ± {self.std_b:.2f} "
+            f"(IC 95 % [{self.ci_b[0]:.2f} ; {self.ci_b[1]:.2f}], n={self.n_b}) ; "
+            f"{self.test_name}, stat={self.statistic:.3f}, p={self.p_value:.4f}{holm_text}, "
+            f"g={self.hedges_g:.2f} (effet {effect_size_label(self.hedges_g)}), "
+            f"δ={self.cliffs_delta:.2f}"
+        )
+
+
+def _is_normal(values: list[float], alpha: float = 0.05) -> bool:
+    """Shapiro-Wilk screen; degenerate/constant samples are non-normal."""
+    if len(values) < 3 or float(np.std(values)) == 0.0:
+        return False
+    return float(sps.shapiro(values).pvalue) >= alpha
+
+
+def compare_groups(
+    a: list[float],
+    b: list[float],
+    label_a: str,
+    label_b: str,
+    metric: str = "reward",
+) -> ComparisonResult:
+    """Compare two run-level samples per the protocol's decision tree.
+
+    Both samples normal (Shapiro-Wilk) → Welch t-test, otherwise
+    Mann-Whitney U. When the two tests disagree on significance at α=0.05,
+    the other test's p-value is attached as ``secondary_*`` so the report can
+    surface the ambiguity instead of hiding it.
+    """
+    normal_a, normal_b = _is_normal(a), _is_normal(b)
+    welch = sps.ttest_ind(a, b, equal_var=False)
+    mannwhitney = sps.mannwhitneyu(a, b, alternative="two-sided")
+    if normal_a and normal_b:
+        test_name, statistic, p_value = "welch", float(welch.statistic), float(welch.pvalue)
+        other_name, other_p = "mann-whitney", float(mannwhitney.pvalue)
+    else:
+        test_name, statistic, p_value = (
+            "mann-whitney",
+            float(mannwhitney.statistic),
+            float(mannwhitney.pvalue),
+        )
+        other_name, other_p = "welch", float(welch.pvalue)
+    disagree = (p_value < 0.05) != (other_p < 0.05)
+    return ComparisonResult(
+        label_a=label_a,
+        label_b=label_b,
+        metric=metric,
+        mean_a=float(np.mean(a)),
+        std_a=float(np.std(a, ddof=1)) if len(a) > 1 else 0.0,
+        ci_a=mean_ci95(a),
+        n_a=len(a),
+        mean_b=float(np.mean(b)),
+        std_b=float(np.std(b, ddof=1)) if len(b) > 1 else 0.0,
+        ci_b=mean_ci95(b),
+        n_b=len(b),
+        normal_a=normal_a,
+        normal_b=normal_b,
+        test_name=test_name,
+        statistic=statistic,
+        p_value=p_value,
+        p_holm=None,
+        hedges_g=hedges_g(a, b),
+        cliffs_delta=cliffs_delta(a, b),
+        secondary_test_name=other_name if disagree else None,
+        secondary_p_value=other_p if disagree else None,
+    )
+
+
+def apply_holm(results: list[ComparisonResult]) -> list[ComparisonResult]:
+    """Attach Holm-adjusted p-values to a family of comparisons (in place)."""
+    adjusted = holm_correction([r.p_value for r in results])
+    for result, p_holm in zip(results, adjusted, strict=True):
+        result.p_holm = p_holm
+    return results

--- a/src/benchmarking/value_iteration.py
+++ b/src/benchmarking/value_iteration.py
@@ -1,0 +1,87 @@
+"""Optimal-policy reference for Taxi-v3 via value iteration.
+
+Value iteration uses the exact transition model ``env.unwrapped.P`` exposed
+by Gymnasium's toy-text environments. It serves ONLY as a measuring stick
+(R*, the reward of an optimal policy on the evaluation seed set, defining the
+0.9·R* convergence threshold) — the trained agents themselves remain strictly
+model-free as required by the subject.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import numpy as np
+import numpy.typing as npt
+
+from src.environments.taxi_wrapper import TaxiEnvWrapper
+
+FloatArray = npt.NDArray[np.float64]
+
+
+def optimal_q_table(
+    env: TaxiEnvWrapper, gamma: float = 0.99, tolerance: float = 1e-10
+) -> FloatArray:
+    """Compute Q* for the wrapped Taxi-v3 env by value iteration.
+
+    Args:
+        env: Wrapped Taxi-v3 environment (must expose ``unwrapped.P``).
+        gamma: Discount factor of the reference policy.
+        tolerance: Sup-norm convergence threshold.
+
+    Returns:
+        The optimal Q-table of shape (n_states, n_actions).
+    """
+    transitions = cast(dict[int, dict[int, list[Any]]], env.env.unwrapped.P)  # type: ignore[attr-defined]
+    n_states, n_actions = env.n_states, env.n_actions
+    values: FloatArray = np.zeros(n_states, dtype=np.float64)
+    while True:
+        q = _q_from_values(transitions, values, n_states, n_actions, gamma)
+        new_values = q.max(axis=1)
+        if float(np.abs(new_values - values).max()) < tolerance:
+            return q
+        values = new_values
+
+
+def _q_from_values(
+    transitions: dict[int, dict[int, list[Any]]],
+    values: FloatArray,
+    n_states: int,
+    n_actions: int,
+    gamma: float,
+) -> FloatArray:
+    q: FloatArray = np.zeros((n_states, n_actions), dtype=np.float64)
+    for state, actions in transitions.items():
+        for action, outcomes in actions.items():
+            total = 0.0
+            for probability, next_state, reward, terminated in outcomes:
+                bootstrap = 0.0 if terminated else gamma * values[next_state]
+                total += probability * (reward + bootstrap)
+            q[state, action] = total
+    return q
+
+
+def optimal_reference_reward(env: TaxiEnvWrapper, seeds: list[int], gamma: float = 0.99) -> float:
+    """R*: mean native reward of the optimal policy over the given episodes.
+
+    Args:
+        env: Wrapped Taxi-v3 environment.
+        seeds: Evaluation seed list (one seed per episode) — use the same
+            fixed set as agent evaluations for a comparable reference.
+        gamma: Discount used for the value-iteration policy.
+
+    Returns:
+        Mean cumulative native reward of the greedy optimal policy.
+    """
+    q_star = optimal_q_table(env, gamma)
+    rewards: list[float] = []
+    for seed in seeds:
+        state, _ = env.reset(seed=seed)
+        total = 0.0
+        terminated = truncated = False
+        while not (terminated or truncated):
+            action = int(np.argmax(q_star[state]))
+            state, _, terminated, truncated, info = env.step(action)
+            total += float(info["raw_reward"])
+        rewards.append(total)
+    return float(np.mean(rewards))

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -245,10 +245,130 @@ def cmd_play(args: argparse.Namespace) -> int:
 
 
 def cmd_benchmark(args: argparse.Namespace) -> int:
-    print("the benchmark command lands with feature/benchmarking-viz")
-    return 2
+    """Hyperparameter sweep defined by a YAML file (grid search)."""
+    import dataclasses
+    import itertools
+
+    import yaml
+
+    from src.benchmarking.benchmarker import (
+        RunSpec,
+        aggregate_runs,
+        run_block,
+        write_optimized_yaml,
+    )
+
+    with open(args.sweep_config) as handle:
+        sweep_config = yaml.safe_load(handle)
+    exp_id = sweep_config.get("exp_id", "sweep")
+    base = Config(**sweep_config.get("base", {}))
+    algorithms: list[str] = sweep_config.get("algorithms", ["q_learning"])
+    grid: dict[str, list[object]] = sweep_config.get("sweep", {})
+    n_seeds: int = int(sweep_config.get("n_seeds", 10))
+    seed_base: int = int(sweep_config.get("seed_base", 42))
+
+    specs: list[RunSpec] = []
+    param_names = list(grid)
+    combos = list(itertools.product(*(grid[name] for name in param_names))) or [()]
+    for algorithm in algorithms:
+        for combo in combos:
+            overrides = dict(zip(param_names, combo, strict=True))
+            config = dataclasses.replace(base, algorithm=algorithm, **overrides)  # type: ignore[arg-type]
+            specs.extend(
+                RunSpec(exp_id=exp_id, config=config, seed=seed_base + k) for k in range(n_seeds)
+            )
+    print(
+        f"sweep {exp_id}: {len(algorithms)} algo(s) x {len(combos)} combo(s) x "
+        f"{n_seeds} seed(s) = {len(specs)} runs on {args.workers} workers"
+    )
+    run_block(specs, results_root=args.out, n_workers=args.workers)
+
+    frame = aggregate_runs(args.out, exp_id, r_star=args.r_star)
+    group_cols = ["algorithm", "config_hash", *param_names]
+    ranking = (
+        frame.groupby(group_cols, dropna=False)["eval_mean_reward"]
+        .agg(["mean", "std", "count"])
+        .sort_values("mean", ascending=False)
+        .reset_index()
+    )
+    print("\ntop 5 configurations (mean test reward across seeds):")
+    print(ranking.head(5).to_string(index=False))
+
+    if args.write_optimized:
+        best = ranking.iloc[0]
+        best_overrides = {name: best[name] for name in param_names if name in ranking.columns}
+        best_overrides["algorithm"] = str(best["algorithm"])
+        best_config = dataclasses.replace(base, **best_overrides)
+        write_optimized_yaml(
+            best_config,
+            OPTIMIZED_CONFIG_PATH,
+            note=(
+                f"Grid-search winner of '{exp_id}' "
+                f"(mean test reward {best['mean']:.3f} over {int(best['count'])} seeds)."
+            ),
+        )
+        print(f"\noptimized configuration written to {OPTIMIZED_CONFIG_PATH}")
+    return 0
 
 
 def cmd_compare(args: argparse.Namespace) -> int:
-    print("the compare command lands with feature/benchmarking-viz")
-    return 2
+    """Head-to-head agent comparison under identical conditions."""
+    import dataclasses
+
+    from src.benchmarking.benchmarker import RunSpec, aggregate_runs, run_block
+    from src.benchmarking.stats import apply_holm, compare_groups
+
+    algorithms = [name.strip() for name in args.agents.split(",") if name.strip()]
+    base = Config()
+    if args.n_train_episodes is not None:
+        base = dataclasses.replace(base, n_train_episodes=args.n_train_episodes)
+    if args.n_test_episodes is not None:
+        base = dataclasses.replace(base, n_test_episodes=args.n_test_episodes)
+
+    specs = [
+        RunSpec(
+            exp_id="compare",
+            config=dataclasses.replace(base, algorithm=algorithm),
+            seed=base.seed + k,
+        )
+        for algorithm in algorithms
+        for k in range(args.n_seeds)
+    ]
+    print(f"compare: {len(algorithms)} agents x {args.n_seeds} seeds = {len(specs)} runs")
+    run_block(specs, results_root=args.out, n_workers=args.workers)
+
+    frame = aggregate_runs(args.out, "compare")
+    frame = frame[frame["algorithm"].isin(algorithms)]
+    table = (
+        frame.groupby("algorithm")
+        .agg(
+            reward=("eval_mean_reward", "mean"),
+            reward_std=("eval_mean_reward", "std"),
+            steps=("eval_mean_steps", "mean"),
+            success=("eval_success_rate", "mean"),
+            train_s=("train_wall_time_s", "mean"),
+            memory_kb=("memory_bytes", lambda b: b.mean() / 1024),
+        )
+        .sort_values("reward", ascending=False)
+    )
+    print("\ncomparison (means over seeds, identical eval episodes):")
+    print(table.round(3).to_string())
+
+    reference = "q_learning" if "q_learning" in algorithms else algorithms[0]
+    reference_rewards = frame[frame["algorithm"] == reference]["eval_mean_reward"].tolist()
+    comparisons = [
+        compare_groups(
+            frame[frame["algorithm"] == algorithm]["eval_mean_reward"].tolist(),
+            reference_rewards,
+            algorithm,
+            reference,
+        )
+        for algorithm in algorithms
+        if algorithm != reference
+    ]
+    if comparisons:
+        apply_holm(comparisons)
+        print(f"\npairwise tests vs {reference} (Holm-corrected):")
+        for comparison in comparisons:
+            print("  " + comparison.format_fr())
+    return 0

--- a/src/cli/parser.py
+++ b/src/cli/parser.py
@@ -94,18 +94,30 @@ def build_parser() -> argparse.ArgumentParser:
     play.add_argument("--seed", type=int, default=None)
 
     benchmark = subparsers.add_parser(
-        "benchmark", help="run the experiment campaign (feature/benchmarking-viz)"
+        "benchmark", help="hyperparameter sweep defined by a YAML grid"
     )
     benchmark.add_argument("--sweep-config", default="configs/benchmark_sweep.yaml")
     benchmark.add_argument("--out", default="results")
-
-    compare = subparsers.add_parser(
-        "compare", help="compare agents head-to-head (feature/benchmarking-viz)"
+    benchmark.add_argument("--workers", type=int, default=6)
+    benchmark.add_argument(
+        "--r-star",
+        dest="r_star",
+        type=float,
+        default=None,
+        help="optimal reference reward for episodes-to-threshold aggregation",
     )
+    benchmark.add_argument(
+        "--write-optimized",
+        action="store_true",
+        help="write the winning configuration to configs/optimized.yaml",
+    )
+
+    compare = subparsers.add_parser("compare", help="compare agents head-to-head")
     compare.add_argument("--agents", default="brute_force,q_learning,sarsa")
     compare.add_argument("--train-episodes", dest="n_train_episodes", type=int, default=None)
     compare.add_argument("--test-episodes", dest="n_test_episodes", type=int, default=None)
     compare.add_argument("--n-seeds", type=int, default=5)
     compare.add_argument("--out", default="results")
+    compare.add_argument("--workers", type=int, default=6)
 
     return parser

--- a/src/evaluation/metrics.py
+++ b/src/evaluation/metrics.py
@@ -49,6 +49,9 @@ class EvalResults:
     mean_episode_seconds: float
     rewards: list[float] = field(repr=False)
     steps: list[int] = field(repr=False)
+    successes: list[bool] = field(repr=False)
+    illegal_actions: list[int] = field(repr=False)
+    durations: list[float] = field(repr=False)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -118,4 +121,7 @@ def compute_eval_results(
         mean_episode_seconds=float(np.mean(durations)),
         rewards=list(rewards),
         steps=list(steps),
+        successes=list(successes),
+        illegal_actions=list(illegal_actions),
+        durations=list(durations),
     )

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -45,6 +45,7 @@ class TrainingHistory:
     probe_episodes: list[int] = field(default_factory=list)
     probe_rewards: list[float] = field(default_factory=list)
     probe_steps: list[float] = field(default_factory=list)
+    probe_max_q: list[float] = field(default_factory=list)
     wall_time: float = 0.0
     stop_reason: str = "completed"
 
@@ -178,3 +179,24 @@ class Trainer:
         history.probe_episodes.append(episode + 1)
         history.probe_rewards.append(results.mean_reward)
         history.probe_steps.append(results.mean_steps)
+        history.probe_max_q.append(self._probe_start_state_value())
+
+    def _probe_start_state_value(self) -> float:
+        """Mean max-a Q(s0, a) over probe start states (overestimation signal).
+
+        Compared across algorithms against the same realized probe returns,
+        the inflation of this estimate exposes Q-Learning's max-operator bias
+        (protocol H7). NaN when the agent exposes no value estimates.
+        """
+        import math
+
+        from src.utils.seeding import probe_seeds
+
+        q_values = getattr(self.agent, "q_values", None)
+        if not callable(q_values) or self.probe_env is None:
+            return math.nan
+        values = []
+        for seed in probe_seeds(self.config.seed, self.config.n_probe_episodes):
+            state, _ = self.probe_env.reset(seed=seed)
+            values.append(float(max(q_values(state))))
+        return sum(values) / len(values)

--- a/src/visualization/episode_replay.py
+++ b/src/visualization/episode_replay.py
@@ -1,0 +1,56 @@
+"""Episode replay exports: animated GIF of a greedy episode."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import gymnasium as gym
+import numpy as np
+
+if TYPE_CHECKING:
+    from src.agents.base_agent import BaseAgent
+
+
+def save_episode_gif(
+    agent: BaseAgent,
+    out_path: str | Path,
+    seed: int = 42,
+    env_id: str = "Taxi-v3",
+    fps: int = 3,
+    max_steps: int = 60,
+) -> Path:
+    """Render one greedy episode to an animated GIF (report/presentation).
+
+    Uses a dedicated ``rgb_array`` environment instance (pygame-backed), so
+    the agent's training/evaluation envs are untouched.
+
+    Args:
+        agent: Trained agent, played greedily.
+        out_path: GIF destination.
+        seed: Episode seed.
+        env_id: Gymnasium environment id.
+        fps: Animation speed.
+        max_steps: Safety cap.
+
+    Returns:
+        The written path.
+    """
+    import imageio.v3 as iio
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    env = gym.make(env_id, render_mode="rgb_array")
+    try:
+        state, _ = env.reset(seed=seed)
+        frames: list[Any] = [env.render()]
+        for _ in range(max_steps):
+            action = agent.select_action(int(state), greedy=True)
+            state, _, terminated, truncated, _ = env.step(action)
+            frames.append(env.render())
+            if terminated or truncated:
+                break
+        iio.imwrite(out_path, [np.asarray(f) for f in frames], duration=1000 // fps, loop=0)
+    finally:
+        env.close()
+    return out_path

--- a/src/visualization/plots.py
+++ b/src/visualization/plots.py
@@ -1,0 +1,272 @@
+"""Figure generators for the benchmark report (all data-driven, PNG 300 dpi).
+
+Every function takes already-loaded data plus an output path, so any figure
+can be regenerated from ``results/raw`` CSVs without re-running experiments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless rendering, before pyplot import
+
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.typing as npt
+from matplotlib.figure import Figure
+
+from src.evaluation.evaluator import ACTION_NAMES
+
+FloatArray = npt.NDArray[np.float64]
+DPI = 300
+
+
+def _save(fig: Figure, out_path: str | Path) -> Path:
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out_path, dpi=DPI, bbox_inches="tight")
+    plt.close(fig)
+    return out_path
+
+
+def rolling_mean(values: list[float], window: int = 100) -> FloatArray:
+    """Trailing rolling mean with a growing window at the start."""
+    arr = np.asarray(values, dtype=np.float64)
+    if len(arr) == 0:
+        return arr
+    cumsum = np.cumsum(arr)
+    out = np.empty_like(arr)
+    for i in range(len(arr)):
+        lo = max(0, i - window + 1)
+        out[i] = (cumsum[i] - (cumsum[lo - 1] if lo > 0 else 0.0)) / (i - lo + 1)
+    return out
+
+
+def learning_curves(
+    series: dict[str, list[list[float]]],
+    out_path: str | Path,
+    window: int = 100,
+    ylabel: str = "Récompense native par épisode",
+    title: str = "Courbes d'apprentissage",
+) -> Path:
+    """Overlaid learning curves with inter-seed mean ± std band (F1/F2).
+
+    Args:
+        series: label -> list of per-seed episode series (equal lengths per
+            label; lengths may differ across labels).
+        out_path: PNG destination.
+        window: Rolling-mean window.
+        ylabel: Y-axis label.
+        title: Figure title.
+    """
+    fig, ax = plt.subplots(figsize=(9, 5.5))
+    for label, runs in series.items():
+        smoothed = np.stack([rolling_mean(run, window) for run in runs])
+        mean = smoothed.mean(axis=0)
+        std = smoothed.std(axis=0)
+        episodes = np.arange(len(mean))
+        (line,) = ax.plot(episodes, mean, label=label, linewidth=1.4)
+        ax.fill_between(episodes, mean - std, mean + std, alpha=0.15, color=line.get_color())
+    ax.set_xlabel("Épisode")
+    ax.set_ylabel(ylabel)
+    ax.set_title(f"{title} (moyenne glissante {window}, bande ± σ inter-seeds)")
+    ax.legend(loc="lower right", fontsize=9)
+    ax.grid(alpha=0.3)
+    return _save(fig, out_path)
+
+
+def probe_curves(
+    series: dict[str, tuple[list[int], list[list[float]]]],
+    out_path: str | Path,
+    xlabel: str = "Épisode d'entraînement",
+    ylabel: str = "Récompense greedy (sondes)",
+    title: str = "Convergence mesurée par sondes greedy",
+    threshold: float | None = None,
+    log_x: bool = False,
+) -> Path:
+    """Greedy-probe curves (mean ± std across seeds), optional threshold line."""
+    fig, ax = plt.subplots(figsize=(9, 5.5))
+    for label, (episodes, runs) in series.items():
+        arr = np.stack([np.asarray(r, dtype=np.float64) for r in runs])
+        mean = arr.mean(axis=0)
+        std = arr.std(axis=0)
+        (line,) = ax.plot(episodes, mean, label=label, linewidth=1.4)
+        ax.fill_between(episodes, mean - std, mean + std, alpha=0.15, color=line.get_color())
+    if threshold is not None:
+        ax.axhline(threshold, linestyle="--", color="grey", linewidth=1)
+        ax.annotate(
+            f"seuil 0.9·R* = {threshold:.2f}",
+            xy=(0.02, threshold),
+            xycoords=("axes fraction", "data"),
+            fontsize=8,
+            color="grey",
+            va="bottom",
+        )
+    if log_x:
+        ax.set_xscale("log")
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.legend(loc="lower right", fontsize=9)
+    ax.grid(alpha=0.3)
+    return _save(fig, out_path)
+
+
+def reward_boxplots(
+    groups: dict[str, list[float]],
+    out_path: str | Path,
+    ylabel: str = "Récompense moyenne de test (par run)",
+    title: str = "Distribution des performances finales",
+) -> Path:
+    """Boxplots with individual run points overlaid (F3)."""
+    fig, ax = plt.subplots(figsize=(max(6, 1.4 * len(groups)), 5))
+    labels = list(groups)
+    data = [groups[label] for label in labels]
+    ax.boxplot(data, tick_labels=labels, showmeans=True)
+    rng = np.random.default_rng(0)
+    for i, values in enumerate(data, start=1):
+        jitter = rng.uniform(-0.08, 0.08, size=len(values))
+        ax.scatter(np.full(len(values), i) + jitter, values, s=14, alpha=0.6, zorder=3)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.tick_params(axis="x", rotation=20)
+    ax.grid(alpha=0.3, axis="y")
+    return _save(fig, out_path)
+
+
+def steps_barplot(
+    means: dict[str, float],
+    ci_halfwidths: dict[str, float],
+    out_path: str | Path,
+    title: str = "Nombre moyen de pas par épisode (IC 95 %)",
+    log_scale: bool = False,
+) -> Path:
+    """Barplot of mean steps with CI error bars; log scale fits brute force (F4)."""
+    fig, ax = plt.subplots(figsize=(max(6, 1.3 * len(means)), 5))
+    labels = list(means)
+    values = [means[label] for label in labels]
+    errors = [ci_halfwidths.get(label, 0.0) for label in labels]
+    bars = ax.bar(labels, values, yerr=errors, capsize=4)
+    for bar, value in zip(bars, values, strict=True):
+        ax.annotate(
+            f"{value:.1f}",
+            xy=(bar.get_x() + bar.get_width() / 2, value),
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+    if log_scale:
+        ax.set_yscale("log")
+    ax.set_ylabel("Pas par épisode" + (" (échelle log)" if log_scale else ""))
+    ax.set_title(title)
+    ax.tick_params(axis="x", rotation=20)
+    ax.grid(alpha=0.3, axis="y")
+    return _save(fig, out_path)
+
+
+def grid_search_heatmap(
+    frame: Any,
+    out_path: str | Path,
+    value_column: str = "eval_mean_reward",
+    row_param: str = "alpha",
+    col_param: str = "gamma",
+    title: str = "Grid search Q-Learning : récompense finale",
+) -> Path:
+    """α×γ heatmap of a grid-search aggregate (F5). ``frame``: runs DataFrame."""
+    import seaborn as sns
+
+    pivot = frame.pivot_table(
+        index=row_param, columns=col_param, values=value_column, aggfunc="mean"
+    )
+    fig, ax = plt.subplots(figsize=(7, 5))
+    sns.heatmap(pivot, annot=True, fmt=".2f", cmap="viridis", ax=ax)
+    ax.set_title(f"{title} (moyenne sur les seeds)")
+    ax.set_xlabel(f"γ ({col_param})")
+    ax.set_ylabel(f"α ({row_param})")
+    return _save(fig, out_path)
+
+
+def sensitivity_curves(
+    frame: Any,
+    param: str,
+    out_path: str | Path,
+    value_column: str = "eval_mean_reward",
+    group_column: str | None = "algorithm",
+    title: str | None = None,
+) -> Path:
+    """Mean ± std of a metric versus one hyperparameter (F6)."""
+    fig, ax = plt.subplots(figsize=(7, 5))
+    groups = [None] if group_column is None else sorted(frame[group_column].unique())
+    for group in groups:
+        subset = frame if group is None else frame[frame[group_column] == group]
+        agg = subset.groupby(param)[value_column].agg(["mean", "std"]).reset_index()
+        label = str(group) if group is not None else value_column
+        ax.errorbar(agg[param], agg["mean"], yerr=agg["std"].fillna(0.0), marker="o", label=label)
+    ax.set_xlabel(param)
+    ax.set_ylabel(value_column)
+    ax.set_title(title or f"Sensibilité à {param}")
+    ax.legend(fontsize=9)
+    ax.grid(alpha=0.3)
+    return _save(fig, out_path)
+
+
+def q_values_heatmap(
+    q_table: FloatArray,
+    decode_state: Any,
+    out_path: str | Path,
+    title: str = "Q-values maximales par case (passager à bord, destination B)",
+    passenger_loc: int = 4,
+    destination: int = 3,
+) -> Path:
+    """5×5 per-action heatmaps of Q-values for a fixed passenger/dest context (F11).
+
+    Args:
+        q_table: (500, 6) learned table.
+        decode_state: Unused placeholder for API symmetry (encoding is done
+            locally); kept to make the data source explicit at call sites.
+        out_path: PNG destination.
+        title: Figure title.
+        passenger_loc: Passenger component of the visualised slice.
+        destination: Destination component of the visualised slice.
+    """
+    fig, axes = plt.subplots(2, 3, figsize=(13, 7))
+    for action in range(6):
+        grid = np.zeros((5, 5))
+        for row in range(5):
+            for col in range(5):
+                state = ((row * 5 + col) * 5 + passenger_loc) * 4 + destination
+                grid[row, col] = q_table[state, action]
+        ax = axes[action // 3][action % 3]
+        image = ax.imshow(grid, cmap="coolwarm")
+        ax.set_title(ACTION_NAMES[action], fontsize=10)
+        ax.set_xticks(range(5))
+        ax.set_yticks(range(5))
+        fig.colorbar(image, ax=ax, shrink=0.8)
+    fig.suptitle(title)
+    return _save(fig, out_path)
+
+
+def sample_efficiency_plot(
+    series: dict[str, tuple[list[float], list[list[float]]]],
+    out_path: str | Path,
+    xlabel: str = "Pas d'environnement cumulés",
+    title: str = "Efficacité en échantillons (échelle log)",
+) -> Path:
+    """Greedy reward vs cumulative env steps, log x (F9, tabular vs DQN)."""
+    fig, ax = plt.subplots(figsize=(9, 5.5))
+    for label, (x_values, runs) in series.items():
+        arr = np.stack([np.asarray(r, dtype=np.float64) for r in runs])
+        mean = arr.mean(axis=0)
+        std = arr.std(axis=0)
+        (line,) = ax.plot(x_values, mean, label=label, linewidth=1.4)
+        ax.fill_between(x_values, mean - std, mean + std, alpha=0.15, color=line.get_color())
+    ax.set_xscale("log")
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel("Récompense greedy (sondes)")
+    ax.set_title(title)
+    ax.legend(loc="lower right", fontsize=9)
+    ax.grid(alpha=0.3, which="both")
+    return _save(fig, out_path)

--- a/tests/benchmarking/test_benchmarker.py
+++ b/tests/benchmarking/test_benchmarker.py
@@ -1,0 +1,103 @@
+"""Benchmarker tests: run persistence, idempotency, aggregation, thresholds."""
+
+import dataclasses
+from pathlib import Path
+
+from src.benchmarking.benchmarker import (
+    RunSpec,
+    aggregate_runs,
+    episodes_to_threshold,
+    find_completed_run,
+    run_single,
+    write_optimized_yaml,
+)
+from src.config import Config
+
+TINY = Config(
+    algorithm="q_learning",
+    n_train_episodes=40,
+    n_test_episodes=5,
+    eval_interval=10,
+    n_probe_episodes=2,
+)
+
+
+class TestRunSingle:
+    def test_writes_all_artifacts(self, tmp_path: Path) -> None:
+        spec = RunSpec(exp_id="tst", config=TINY, seed=42)
+        summary = run_single(spec, results_root=tmp_path)
+        run_dirs = list((tmp_path / "raw" / "tst").glob("q_learning__*__s42__*"))
+        assert len(run_dirs) == 1
+        for name in (
+            "config.json",
+            "train_episodes.csv",
+            "probes.csv",
+            "eval_episodes.csv",
+            "summary.json",
+        ):
+            assert (run_dirs[0] / name).exists(), name
+        assert summary["n_train_episodes"] == 40
+        assert summary["algorithm"] == "q_learning"
+        assert len(summary["probe_episodes"]) == 4  # every 10 of 40
+        # train csv has header + 40 rows
+        lines = (run_dirs[0] / "train_episodes.csv").read_text().strip().splitlines()
+        assert len(lines) == 41
+        # eval csv has the fixed eval seeds
+        eval_lines = (run_dirs[0] / "eval_episodes.csv").read_text().strip().splitlines()
+        assert len(eval_lines) == 6
+        assert "10042" in eval_lines[1]  # EVAL_BASE_SEED + offset
+
+    def test_idempotent_resume(self, tmp_path: Path) -> None:
+        spec = RunSpec(exp_id="tst", config=TINY, seed=43)
+        first = run_single(spec, results_root=tmp_path)
+        assert find_completed_run(tmp_path, spec) is not None
+        second = run_single(spec, results_root=tmp_path)  # must reuse, not re-train
+        assert first == second
+        assert len(list((tmp_path / "raw" / "tst").glob("*__s43__*"))) == 1
+
+    def test_zero_training_episodes_brute_force(self, tmp_path: Path) -> None:
+        config = dataclasses.replace(TINY, algorithm="brute_force", n_train_episodes=0)
+        summary = run_single(RunSpec("tst", config, 42), results_root=tmp_path)
+        assert summary["n_train_episodes"] == 0
+        assert summary["first_success_episode"] is None
+        assert summary["post_convergence_std"] is None
+        assert summary["eval_mean_reward"] < 0  # random policy is terrible
+
+    def test_shaped_run_reports_native_rewards(self, tmp_path: Path) -> None:
+        config = dataclasses.replace(TINY, reward_shaping="potential")
+        summary = run_single(RunSpec("tst", config, 44), results_root=tmp_path)
+        # native eval rewards on Taxi are bounded by 20 - steps
+        assert summary["eval_mean_reward"] <= 20
+
+
+class TestAggregation:
+    def test_aggregate_and_threshold(self, tmp_path: Path) -> None:
+        for seed in (42, 43):
+            run_single(RunSpec("agg", TINY, seed), results_root=tmp_path)
+        frame = aggregate_runs(tmp_path, "agg", r_star=8.0)
+        assert len(frame) == 2
+        assert {
+            "algorithm",
+            "seed",
+            "eval_mean_reward",
+            "episodes_to_threshold",
+            "converged",
+        } <= set(frame.columns)
+        assert (tmp_path / "aggregated" / "agg__runs.csv").exists()
+
+    def test_episodes_to_threshold_sustain_logic(self) -> None:
+        episodes = [100, 200, 300, 400, 500]
+        # single spike does not count; sustained window returns its start
+        assert episodes_to_threshold(episodes, [1, 9, 1, 1, 1], 8.0, sustain=3) is None
+        assert episodes_to_threshold(episodes, [1, 9, 9, 9, 1], 8.0, sustain=3) == 200
+        assert episodes_to_threshold(episodes, [9, 9, 1, 9, 9], 8.0, sustain=3) is None
+
+
+class TestWriteOptimized:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        path = tmp_path / "optimized.yaml"
+        write_optimized_yaml(TINY, path, note="test note")
+        loaded = Config.from_yaml(path)
+        assert loaded.algorithm == "q_learning"
+        assert loaded.mode == "time_limited"
+        assert "test note" in path.read_text()

--- a/tests/benchmarking/test_shaping_vi.py
+++ b/tests/benchmarking/test_shaping_vi.py
@@ -1,0 +1,94 @@
+"""Reward shaping and value-iteration reference tests."""
+
+import itertools
+
+import pytest
+
+from src.benchmarking.reward_shaping import (
+    _decode,
+    create_reward_shaper,
+    make_naive_distance_shaper,
+    make_potential_shaper,
+    make_step_penalty_shaper,
+    potential,
+)
+from src.benchmarking.value_iteration import optimal_q_table, optimal_reference_reward
+from src.config import Config
+from src.environments import create_env
+from src.utils.seeding import eval_seeds
+
+
+class TestDecode:
+    def test_matches_env_decode(self) -> None:
+        env = create_env(Config())
+        for state in (0, 137, 258, 399, 499):
+            assert _decode(state) == env.decode_state(state)
+
+
+class TestPotentialShaping:
+    def test_telescoping_sum_along_trajectory(self) -> None:
+        """Potential-based shaping adds γΦ(s_T)−Φ(s_0) over any trajectory."""
+        gamma = 0.9
+        shaper = make_potential_shaper(gamma)
+        trajectory = [42, 142, 262, 258]  # arbitrary state chain
+        rewards = [-1.0, -1.0, -1.0]
+        shaped_sum = sum(
+            shaper(s, 0, r, s2)
+            for s, r, s2 in zip(trajectory, rewards, trajectory[1:], strict=False)
+        )
+        native_sum = sum(rewards)
+        # telescoping with discount 0.9 leaves a weighted potential difference
+        expected_extra = sum(
+            gamma * potential(s2) - potential(s) for s, s2 in itertools.pairwise(trajectory)
+        )
+        assert shaped_sum == pytest.approx(native_sum + expected_extra)
+
+    def test_moving_toward_objective_is_rewarded(self) -> None:
+        shaper = make_potential_shaper(1.0)
+        # state with passenger at R(0,0): taxi at (0,1) → (0,0) gets closer
+        state_far = ((0 * 5 + 1) * 5 + 0) * 4 + 1  # taxi (0,1), passenger R, dest G
+        state_near = ((0 * 5 + 0) * 5 + 0) * 4 + 1  # taxi (0,0)
+        assert shaper(state_far, 3, -1.0, state_near) > -1.0
+        assert shaper(state_near, 2, -1.0, state_far) < -1.0
+
+
+class TestOtherShapers:
+    def test_naive_bonus_only_on_progress(self) -> None:
+        shaper = make_naive_distance_shaper(bonus=0.5)
+        state_far = ((0 * 5 + 1) * 5 + 0) * 4 + 1
+        state_near = ((0 * 5 + 0) * 5 + 0) * 4 + 1
+        assert shaper(state_far, 3, -1.0, state_near) == -0.5
+        assert shaper(state_near, 2, -1.0, state_far) == -1.0
+
+    def test_step_penalty_targets_moves_only(self) -> None:
+        shaper = make_step_penalty_shaper(1.0)
+        assert shaper(0, 0, -1.0, 1) == -2.0
+        assert shaper(0, 5, -10.0, 1) == -10.0
+        assert shaper(0, 5, 20.0, 1) == 20.0
+
+    def test_factory(self) -> None:
+        assert create_reward_shaper("none", 0.99) is None
+        assert create_reward_shaper("potential", 0.99) is not None
+        with pytest.raises(ValueError, match="unknown"):
+            create_reward_shaper("magic", 0.99)
+
+
+class TestValueIteration:
+    def test_r_star_matches_known_taxi_optimum(self) -> None:
+        env = create_env(Config())
+        r_star = optimal_reference_reward(env, eval_seeds(42, 50))
+        assert 7.0 < r_star < 9.0  # literature: ~7.9 for Taxi-v3
+
+    def test_optimal_policy_solves_everything_quickly(self) -> None:
+        import numpy as np
+
+        env = create_env(Config())
+        q_star = optimal_q_table(env)
+        for seed in eval_seeds(42, 20):
+            state, _ = env.reset(seed=seed)
+            for _ in range(30):
+                state, _, terminated, truncated, _ = env.step(int(np.argmax(q_star[state])))
+                assert not truncated
+                if terminated:
+                    break
+            assert terminated

--- a/tests/benchmarking/test_stats.py
+++ b/tests/benchmarking/test_stats.py
@@ -1,0 +1,86 @@
+"""Statistics module tests against hand-computed and scipy references."""
+
+import numpy as np
+import pytest
+from scipy import stats as sps
+
+from src.benchmarking.stats import (
+    apply_holm,
+    cliffs_delta,
+    compare_groups,
+    effect_size_label,
+    hedges_g,
+    holm_correction,
+)
+
+RNG = np.random.default_rng(7)
+NORMAL_A = list(RNG.normal(8.0, 0.4, size=10))
+NORMAL_B = list(RNG.normal(7.2, 0.5, size=10))
+
+
+class TestEffectSizes:
+    def test_hedges_g_sign_and_magnitude(self) -> None:
+        g = hedges_g(NORMAL_A, NORMAL_B)
+        assert g > 0.8  # clearly separated samples → large effect
+        assert hedges_g(NORMAL_B, NORMAL_A) == pytest.approx(-g)
+
+    def test_hedges_g_zero_for_identical(self) -> None:
+        assert hedges_g([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == 0.0
+
+    def test_cliffs_delta_hand_case(self) -> None:
+        # a always greater: delta = +1 ; interleaved gives intermediate value
+        assert cliffs_delta([5.0, 6.0], [1.0, 2.0]) == 1.0
+        assert cliffs_delta([1.0, 2.0], [5.0, 6.0]) == -1.0
+        # pairs: (1,2)<, (1,4)<, (3,2)>, (3,4)< -> (1-3)/4 = -0.5
+        assert cliffs_delta([1.0, 3.0], [2.0, 4.0]) == pytest.approx(-0.5)
+
+    def test_labels(self) -> None:
+        assert effect_size_label(0.1) == "négligeable"
+        assert effect_size_label(-0.9) == "fort"
+
+
+class TestHolm:
+    def test_holm_hand_case(self) -> None:
+        # p = [0.01, 0.04, 0.03] sorted: 0.01*3=0.03, 0.03*2=0.06, 0.04*1=0.04→max(0.06)
+        adjusted = holm_correction([0.01, 0.04, 0.03])
+        assert adjusted[0] == pytest.approx(0.03)
+        assert adjusted[2] == pytest.approx(0.06)
+        assert adjusted[1] == pytest.approx(0.06)  # monotone enforcement
+
+    def test_holm_caps_at_one(self) -> None:
+        assert max(holm_correction([0.9, 0.8, 0.7])) == 1.0
+
+    def test_apply_holm_attaches(self) -> None:
+        results = [
+            compare_groups(NORMAL_A, NORMAL_B, "a", "b"),
+            compare_groups(NORMAL_A, NORMAL_A, "a", "a"),
+        ]
+        apply_holm(results)
+        assert all(r.p_holm is not None for r in results)
+        assert results[0].p_holm >= results[0].p_value
+
+
+class TestCompareGroups:
+    def test_welch_chosen_for_normal_samples(self) -> None:
+        result = compare_groups(NORMAL_A, NORMAL_B, "A", "B")
+        assert result.test_name == "welch"
+        reference = sps.ttest_ind(NORMAL_A, NORMAL_B, equal_var=False)
+        assert result.p_value == pytest.approx(float(reference.pvalue))
+        assert isinstance(result.significant(), bool)
+
+    def test_mannwhitney_chosen_for_non_normal(self) -> None:
+        skewed = [0.1] * 8 + [50.0, 80.0]  # heavily skewed
+        result = compare_groups(skewed, NORMAL_B, "skewed", "B")
+        assert result.test_name == "mann-whitney"
+
+    def test_constant_sample_is_non_normal(self) -> None:
+        result = compare_groups([5.0] * 10, NORMAL_B, "const", "B")
+        assert result.normal_a is False
+        assert result.test_name == "mann-whitney"
+
+    def test_format_fr_contains_protocol_fields(self) -> None:
+        result = compare_groups(NORMAL_A, NORMAL_B, "QL", "SARSA")
+        result.p_holm = 0.02
+        text = result.format_fr()
+        for token in ("IC 95 %", "n=10", "p=", "p_Holm=", "g=", "effet"):
+            assert token in text

--- a/tests/visualization/test_plots.py
+++ b/tests/visualization/test_plots.py
@@ -1,0 +1,105 @@
+"""Visualization tests: every generator produces a PNG from synthetic data."""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.visualization.plots import (
+    grid_search_heatmap,
+    learning_curves,
+    probe_curves,
+    q_values_heatmap,
+    reward_boxplots,
+    rolling_mean,
+    sample_efficiency_plot,
+    sensitivity_curves,
+    steps_barplot,
+)
+
+RNG = np.random.default_rng(0)
+
+
+def _runs(n_runs: int = 3, length: int = 50) -> list[list[float]]:
+    return [list(RNG.normal(i, 1.0, size=length)) for i in range(n_runs)]
+
+
+class TestRollingMean:
+    def test_hand_case(self) -> None:
+        out = rolling_mean([1.0, 2.0, 3.0, 4.0], window=2)
+        assert list(out) == [1.0, 1.5, 2.5, 3.5]
+
+    def test_empty(self) -> None:
+        assert len(rolling_mean([], window=5)) == 0
+
+
+class TestFigureGenerators:
+    def test_learning_curves(self, tmp_path: Path) -> None:
+        path = learning_curves({"QL": _runs(), "SARSA": _runs()}, tmp_path / "f1.png")
+        assert path.exists() and path.stat().st_size > 10_000
+
+    def test_probe_curves_with_threshold(self, tmp_path: Path) -> None:
+        episodes = list(range(100, 600, 100))
+        series = {"QL": (episodes, [[1.0, 3.0, 6.0, 7.5, 7.9]] * 3)}
+        path = probe_curves(series, tmp_path / "probes.png", threshold=7.1)
+        assert path.exists()
+
+    def test_reward_boxplots(self, tmp_path: Path) -> None:
+        groups = {"QL": list(RNG.normal(8, 0.3, 10)), "MC": list(RNG.normal(5, 1.0, 10))}
+        assert reward_boxplots(groups, tmp_path / "f3.png").exists()
+
+    def test_steps_barplot_log(self, tmp_path: Path) -> None:
+        path = steps_barplot(
+            {"brute_force": 350.0, "q_learning": 13.0},
+            {"brute_force": 12.0, "q_learning": 0.4},
+            tmp_path / "f4.png",
+            log_scale=True,
+        )
+        assert path.exists()
+
+    def test_grid_search_heatmap(self, tmp_path: Path) -> None:
+        frame = pd.DataFrame(
+            {
+                "alpha": np.repeat([0.05, 0.15], 4),
+                "gamma": list(np.tile([0.9, 0.99], 2)) * 2,
+                "eval_mean_reward": RNG.normal(7, 0.5, 8),
+            }
+        )
+        assert grid_search_heatmap(frame, tmp_path / "f5.png").exists()
+
+    def test_sensitivity_curves(self, tmp_path: Path) -> None:
+        frame = pd.DataFrame(
+            {
+                "alpha": [0.05, 0.05, 0.15, 0.15] * 2,
+                "algorithm": ["q_learning"] * 4 + ["sarsa"] * 4,
+                "eval_mean_reward": RNG.normal(7, 0.3, 8),
+            }
+        )
+        assert sensitivity_curves(frame, "alpha", tmp_path / "f6.png").exists()
+
+    def test_q_values_heatmap(self, tmp_path: Path) -> None:
+        q_table = RNG.normal(0, 1, size=(500, 6))
+        assert q_values_heatmap(q_table, None, tmp_path / "f11.png").exists()
+
+    def test_sample_efficiency(self, tmp_path: Path) -> None:
+        x = [100.0, 1_000.0, 10_000.0, 100_000.0]
+        series = {"QL": (x, [[-200.0, -50.0, 5.0, 8.0]] * 3)}
+        assert sample_efficiency_plot(series, tmp_path / "f9.png").exists()
+
+
+class TestEpisodeGif:
+    def test_gif_written_for_trained_agent(self, tmp_path: Path) -> None:
+        pytest.importorskip("pygame")
+        from src.agents import create_agent
+        from src.config import Config
+        from src.environments import create_env
+        from src.training.trainer import Trainer
+        from src.visualization.episode_replay import save_episode_gif
+
+        config = Config(algorithm="q_learning", seed=1)
+        env = create_env(config)
+        agent = create_agent(config, env)
+        Trainer(agent, env, config).train(400)
+        path = save_episode_gif(agent, tmp_path / "episode.gif", seed=7, max_steps=40)
+        assert path.exists() and path.stat().st_size > 1_000


### PR DESCRIPTION
## Description
The scientific core of the project (EPIC 5 + EPIC 7 + protocol):

- **Experiment runner**: runs keyed by (exp_id, config_hash, seed) — idempotent (crash-resume), per-run artifacts (config + train/probes/eval CSVs + summary + trained model), Pool parallelism for metric blocks, strictly sequential mode for the timing block, fixed eval seed set shared by every run
- **Statistics** (protocol §5): Shapiro screen → Welch / Mann-Whitney (disagreements surfaced, not hidden), Holm-Bonferroni per hypothesis family, Hedges g + Cliff's δ, French report formatting; unit of analysis = the run (n=10) to avoid pseudo-replication
- **Reward shaping**: potential-based (Ng et al. 1999, policy-preserving), naive-distance negative control, step-penalty; native reward always preserved for metrics
- **R\*** by value iteration on `env.P` (measuring stick only): **8.05** on the fixed eval set, 7.77 on probes — convergence threshold 0.9·R\* sustained 3 checkpoints
- **Figures**: data-driven generators (learning/probe curves with inter-seed bands, boxplots, CI barplots, grid heatmap, sensitivity, Q-value heatmaps, sample-efficiency log plot, GIF replay) + `scripts/make_figures.py` regenerating F1-F12 from results/ only
- **Campaign** `scripts/run_campaign.py`: blocks E0-E7 (~820 runs) per **docs/PROTOCOLE.md** (full French experimental protocol committed), optimized.yaml promoted from the E1a grid winner
- CLI `benchmark` (YAML grid sweep, --write-optimized) and `compare` (head-to-head + Holm-corrected pairwise tests) replace their stubs
- Probe **max-Q instrumentation** (H7 overestimation signal) and per-run model saving

## Tests effectués
45 nouveaux tests : références scipy croisées, cas Holm/Cliff calculés à la main, télescopage du shaping basé potentiel, R* dans [7,9] + politique optimale résout 100 % en <30 pas, idempotence du runner, agrégation avec censure, chaque générateur de figure sur données synthétiques, GIF réel. Local : ruff ✅ black ✅ mypy strict ✅ pytest **224/224** ✅. Intégration : `compare` réel sur 6 runs parallèles ; campagne `--dry-run` = 822 runs.

## Issues liées
Closes #23 (T-5.1.1), Closes #35 (T-5.1.4), Closes #25 (T-7.1.1), Closes #26 (T-7.1.2), Closes #33 (T-7.1.3), Closes #34 (T-7.1.4)
Refs #24 (T-5.1.2), #31 (T-5.1.3), #28 (T-3.2.4) — outillage livré ; fermeture à l'exécution de la campagne

🤖 Generated with [Claude Code](https://claude.com/claude-code)