### PR TITLE
docs: align README and ARCHITECTURE with the executed TrackMania extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The project implements seven algorithms, compares them under a pre-registered ex
 - Experiment campaign **E0–E7** (822 runs, ~4h30–5h30 on 6 cores), resumable and idempotent
 - Statistical pipeline: Welch t-test / Mann-Whitney U, Holm correction per hypothesis family, effect sizes (Hedges g, Cliff's δ)
 - Figure generation (learning curves, boxplots, grid heatmaps, Q-value heatmap, episode GIF) from raw results — no re-runs needed
-- 225 unit/integration tests (slow training tests behind a pytest marker), CI via GitHub Actions
+- 241 unit/integration tests (slow training tests behind a pytest marker), CI via GitHub Actions
 
 ## Getting Started
 
@@ -81,7 +81,7 @@ The project implements seven algorithms, compares them under a pre-registered ex
 git clone https://github.com/T-AIA-902-Taxi-Driver/Taxi-Driver.git
 cd Taxi-Driver
 poetry install                  # core project
-poetry install -E trackmania    # optional: + Stable-Baselines3 for the TrackMania extension
+poetry install -E trackmania    # optional: + SB3, TensorBoard, rich for the TrackMania extension
 ```
 
 > **Note on the Gymnasium pin:** `gymnasium` is pinned to `>=1.0,<1.3` because Taxi-v3 was removed in gymnasium 1.3.0 (replaced by Taxi-v4, which is identical with default parameters). The subject mandates Taxi-v3, hence the pin.
@@ -252,16 +252,20 @@ Taxi-Driver/
 │   └── utils/                     # Seeding helpers
 ├── scripts/
 │   ├── run_campaign.py            # Campaign driver, blocks E0-E7 (822 runs)
-│   ├── make_figures.py            # Figures F1-F12 from results/
+│   ├── make_figures.py            # Figures F1-F14 from results/
 │   ├── run_stats.py               # Hypothesis tests H1-H9
-│   └── train_trackmania.py        # SAC training on TrackMania (game machine only)
+│   ├── check_trackmania_setup.py  # Game-setup validation + tmrl config templating
+│   ├── train_trackmania.py        # SAC training on TrackMania (game machine only)
+│   └── eval_trackmania.py         # Greedy TrackMania eval + lap detection
 ├── configs/
 │   ├── default.yaml               # Commented reference of every field (user mode)
 │   ├── optimized.yaml             # Grid-search winner (time-limited mode)
-│   └── benchmark_sweep.yaml       # E1a grid definition for `benchmark`
-├── models/final/                  # Trained models for the 6 learners
-├── results/                       # aggregated/, figures/, raw/, r_star.json
-├── tests/                         # 225 unit & integration tests
+│   ├── benchmark_sweep.yaml       # E1a grid definition for `benchmark`
+│   ├── trackmania.yaml            # SAC hyperparameters (tmrl-aligned)
+│   └── tmrl_config.json           # Game-machine tmrl config template (secrets redacted)
+├── models/final/                  # Trained models: 6 Taxi learners + TrackMania SAC
+├── results/                       # aggregated/, figures/, raw/, trackmania/, r_star.json
+├── tests/                         # 241 unit & integration tests
 ├── docs/                          # Framing, architecture, protocol, report, TrackMania
 ├── pyproject.toml                 # Poetry config (deps, extras, console script, tooling)
 └── README.md

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@ L'environnement Taxi-v3 est un problème classique de RL épisodique dans lequel
 - Proposer deux modes d'exécution : un mode utilisateur permettant le réglage d'hyperparamètres et un mode optimisé à temps limité.
 - Fournir un framework de benchmarking et de visualisation pour comparer les performances des agents.
 - En bonus, développer un environnement personnalisé avec 2 passagers.
-- En extension bonus, un agent DQN (Deep Q-Network) peut être implémenté pour démontrer le passage au deep RL. De plus, un environnement **TrackMania** peut être intégré comme extension avancée pour démontrer le deep RL sur un espace d'états continu (LIDAR/images) avec des algorithmes comme PPO ou SAC.
+- En extension bonus, un agent DQN (Deep Q-Network) démontre le passage au deep RL. De plus, l'environnement **TrackMania 2020** est intégré comme extension avancée : un agent SAC (Stable-Baselines3) y est entraîné sur le jeu réel, sur un espace d'états continu (LIDAR) — voir `docs/TRACKMANIA.md` pour l'architecture détaillée et les résultats.
 
 ### Stack Technologique (résumé)
 
@@ -161,7 +161,7 @@ Taxi-Driver/
 
 **`src/environments/multi_passenger_env.py`** : Environnement personnalisé héritant de `gymnasium.Env` qui étend Taxi-v3 pour gérer deux passagers simultanément. L'espace d'états et la logique de récompenses sont adaptés pour refléter la complexité accrue du problème multi-passagers.
 
-**`src/environments/trackmania_wrapper.py`** : (Extension bonus) Wrapper autour de l'environnement TrackMania via la bibliothèque `tmrl`, standardisant l'interface Gymnasium pour permettre l'entraînement d'agents deep RL (PPO, SAC via Stable-Baselines3). Fournit des observations sous forme de vecteurs LIDAR (distances aux murs du circuit) et un espace d'actions continu (accélération, direction). Permet la comparaison directe entre RL tabulaire (Taxi-v3) et deep RL (TrackMania).
+**`src/environments/trackmania_wrapper.py`** : (Extension bonus) Wrapper autour de l'environnement temps réel TrackMania 2020 via la bibliothèque `tmrl`, standardisant l'interface Gymnasium pour l'agent SAC (Stable-Baselines3). Aplati et normalise les observations LIDAR (vitesse + 4×19 faisceaux + 2 actions passées → `Box(-1, 1, (83,))`), valide le préréglage tmrl à la construction, gère `wait()`/`close()` du flux temps réel, les échecs transitoires d'attache de la manette virtuelle et la mise au premier plan de la fenêtre de jeu. Permet la comparaison directe entre RL tabulaire (Taxi-v3) et deep RL (TrackMania) — voir `docs/TRACKMANIA.md`.
 
 **`src/training/trainer.py`** : Pipeline d'entraînement générique qui orchestre la boucle épisodique : pour chaque épisode, il réinitialise l'environnement, exécute la boucle pas-à-pas (action, transition, apprentissage), enregistre les métriques et gère les callbacks. Il est agnostique vis-à-vis de l'agent utilisé grâce au pattern Strategy.
 


### PR DESCRIPTION
Post-campaign consistency sweep: README test count (225 -> 241, verified by pytest collection), project tree (new TrackMania scripts and configs, F1-F14, TrackMania model in models/final), trackmania extra description (SB3 + TensorBoard + rich), and ARCHITECTURE.md's TrackMania claims updated from hypothetical ('peut etre integre', 'PPO ou SAC', 'LIDAR/images') to the executed reality (SAC on LIDAR, runtime safeguards, pointer to TRACKMANIA.md). RAPPORT/SLIDES/CHANGELOG/TRACKMANIA.md were verified consistent already. Known pre-existing drift left as-is (out of scope): ARCHITECTURE's generic tree still shows dqn_agent.py as a single file instead of the dqn/ package.